### PR TITLE
Normalize FMDN EID parsing and rate-limit logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Unreleased
+
+- Add configurable FMDN modes and EID parsing, improving manual selection and avoiding duplicate devices through canonical address normalization.
+- Harden FMDN EID candidate extraction and deduplicate shared tracker identities to prevent ghost devices and capture variable-length EIDs.
+- Align MAC normalization with Home Assistant formatting, separate pseudo-identifier handling, and stabilize FMDN metadevice keys to avoid address collisions.

--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.entity_registry import async_migrate_entries
 
 from .const import _LOGGER, DOMAIN, PLATFORMS, STARTUP_MESSAGE
 from .coordinator import BermudaDataUpdateCoordinator
-from .util import mac_math_offset, mac_norm
+from .util import mac_math_offset, normalize_address
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -117,7 +117,7 @@ async def async_remove_config_entry_device(
             pass
     if address is not None:
         try:
-            coordinator.devices[mac_norm(address)].create_sensor = False
+            coordinator.devices[normalize_address(address)].create_sensor = False
         except KeyError:
             _LOGGER.warning("Failed to locate device entry for %s", address)
         return True

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -83,6 +83,7 @@ METADEVICE_IBEACON_DEVICE: Final = "beacon device"  # The meta-device created to
 METADEVICE_TYPE_PRIVATE_BLE_SOURCE: Final = "private_ble_src"  # current (random) MAC of a private ble device
 METADEVICE_PRIVATE_BLE_DEVICE: Final = "private_ble_device"  # meta-device create to track private ble device
 METADEVICE_TYPE_FMDN_SOURCE: Final = "fmdn_source"
+METADEVICE_FMDN_DEVICE: Final = "fmdn_device"
 
 # Protocol constants
 SERVICE_UUID_FMDN = "0000feaa-0000-1000-8000-00805f9b34fb"
@@ -92,7 +93,7 @@ METADEVICE_SOURCETYPES: Final = {
     METADEVICE_TYPE_PRIVATE_BLE_SOURCE,
     METADEVICE_TYPE_FMDN_SOURCE,
 }
-METADEVICE_DEVICETYPES: Final = {METADEVICE_IBEACON_DEVICE, METADEVICE_PRIVATE_BLE_DEVICE}
+METADEVICE_DEVICETYPES: Final = {METADEVICE_IBEACON_DEVICE, METADEVICE_PRIVATE_BLE_DEVICE, METADEVICE_FMDN_DEVICE}
 
 # Bluetooth Device Address Type - classify MAC addresses
 BDADDR_TYPE_UNKNOWN: Final = "bd_addr_type_unknown"  # uninitialised
@@ -172,6 +173,25 @@ DOCS[CONF_DEVICES] = "Identifies which bluetooth devices we wish to expose"
 
 CONF_SCANNERS = "configured_scanners"
 
+CONF_FMDN_MODE = "fmdn_mode"
+FMDN_MODE_RESOLVED_ONLY = "resolved_only"
+FMDN_MODE_SOURCES_ONLY = "sources_only"
+FMDN_MODE_BOTH = "both"
+DEFAULT_FMDN_MODE = FMDN_MODE_RESOLVED_ONLY
+DOCS[CONF_FMDN_MODE] = (
+    "FMDN exposure mode. resolved_only hides ephemeral sources and exposes only the resolved device; "
+    "sources_only surfaces only rotating source MACs; both exposes both."
+)
+CONF_FMDN_EID_FORMAT = "fmdn_eid_format"
+FMDN_EID_FORMAT_STRIP_FRAME_20 = "strip_frame_20"
+FMDN_EID_FORMAT_STRIP_FRAME_ALL = "strip_frame_all"
+FMDN_EID_FORMAT_AUTO = "auto"
+DEFAULT_FMDN_EID_FORMAT = FMDN_EID_FORMAT_STRIP_FRAME_20
+DOCS[CONF_FMDN_EID_FORMAT] = (
+    "FMDN EID extraction strategy. strip_frame_20 keeps the first 20 bytes after the 0x40 frame; "
+    "strip_frame_all keeps all bytes after the frame; auto trims a trailing checksum byte when present."
+)
+FMDN_EID_CANDIDATE_LENGTHS: Final[tuple[int, ...]] = (20, 32)
 
 CONF_MAX_RADIUS, DEFAULT_MAX_RADIUS = "max_area_radius", 20
 DOCS[CONF_MAX_RADIUS] = "For simple area-detection, max radius from receiver"

--- a/custom_components/bermuda/fmdn.py
+++ b/custom_components/bermuda/fmdn.py
@@ -2,12 +2,36 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
-    from collections.abc import Mapping
+from .const import (
+    _LOGGER,
+    DEFAULT_FMDN_EID_FORMAT,
+    FMDN_EID_CANDIDATE_LENGTHS,
+    FMDN_EID_FORMAT_AUTO,
+    FMDN_EID_FORMAT_STRIP_FRAME_20,
+    FMDN_EID_FORMAT_STRIP_FRAME_ALL,
+    SERVICE_UUID_FMDN,
+)
+from .log_spam_less import BermudaLogSpamLess
 
-from .const import SERVICE_UUID_FMDN
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+
+_LAST_MODE_LOGGED: list[str | None] = [None]
+_LOG_SPAM_LESS = BermudaLogSpamLess(_LOGGER, spam_interval=300)
+_FHN_UUID_MARKER = b"\xAA\xFE"  # 0xFEAA in little-endian order as it appears on-air
+_FHN_FRAME_TYPES = (0x40, 0x41)
+
+
+@dataclass(frozen=True)
+class ExtractedEid:
+    """Normalized EID payload parsed from Find Hub Network service data."""
+
+    eid: bytes
+    frame_type: int | None
+    hashed_flags: int | None
 
 
 def _normalize_service_uuid(service_uuid: str | int) -> str:
@@ -23,21 +47,270 @@ def is_fmdn_service_uuid(service_uuid: str | int) -> bool:
     return normalized in {SERVICE_UUID_FMDN, "feaa", "0xfeaa", "0000feaa"}
 
 
-def extract_fmdn_eid(service_data: Mapping[str | int, Any]) -> bytes | None:
-    """Extract the ephemeral identifier from FMDN service data when present."""
+def _log_mode(mode: str) -> None:
+    """Log mode transitions to avoid repeated noisy debug output."""
+    if mode != _LAST_MODE_LOGGED[0]:
+        _LOGGER.debug("Using FMDN EID extraction mode: %s", mode)
+        _LAST_MODE_LOGGED[0] = mode
+
+
+def _log_malformed(mode: str, frame_type: int, payload_len: int, reason: str) -> None:
+    """Log malformed payloads without spamming the logs."""
+    _LOG_SPAM_LESS.debug(
+        f"fmdn_malformed_{mode}_{frame_type:02x}_{payload_len}_{reason}",
+        "Ignoring FMDN payload (mode=%s, frame=0x%02x, len=%d, reason=%s)",
+        mode,
+        frame_type,
+        payload_len,
+        reason,
+    )
+
+
+def _log_candidates(mode: str, frame_type: int, payload_len: int, count: int) -> None:
+    """Log candidate extraction summaries without spamming."""
+    _LOG_SPAM_LESS.debug(
+        f"fmdn_candidates_{mode}_{frame_type:02x}_{payload_len}_{count}",
+        "FMDN candidate extraction (mode=%s, frame=0x%02x, len=%d) yielded %d candidates",
+        mode,
+        frame_type,
+        payload_len,
+        count,
+    )
+
+
+def _normalized_mode(mode: str) -> str:
+    """Return a supported extraction mode, falling back to the default."""
+    if mode in {FMDN_EID_FORMAT_AUTO, FMDN_EID_FORMAT_STRIP_FRAME_ALL, FMDN_EID_FORMAT_STRIP_FRAME_20}:
+        return mode
+    _LOGGER.debug("Unknown FMDN EID format %s; defaulting to %s", mode, DEFAULT_FMDN_EID_FORMAT)
+    return DEFAULT_FMDN_EID_FORMAT
+
+
+def _sliding_window_candidates(payload: bytes, candidate_lengths: Sequence[int]) -> set[bytes]:
+    """Generate sliding-window candidates across a payload."""
+    candidates: set[bytes] = set()
+    for length in candidate_lengths:
+        if length > len(payload):
+            continue
+        for start in range(len(payload) - length + 1):
+            candidates.add(bytes(payload[start : start + length]))
+    return candidates
+
+
+def _prefix_candidates(payload: bytes, candidate_lengths: Sequence[int]) -> set[bytes]:
+    """Generate deterministic prefix candidates (payload[:len]) for each configured length."""
+    candidates: set[bytes] = set()
+    for length in candidate_lengths:
+        if length <= 0:
+            continue
+        if len(payload) >= length:
+            candidates.add(bytes(payload[:length]))
+    return candidates
+
+
+def _auto_trim_checksum_candidates(payload: bytes, candidate_lengths: Sequence[int]) -> set[bytes]:
+    """
+    In auto mode, consider trimming a trailing checksum byte.
+
+    If payload length is exactly (candidate_length + 1), add payload[:-1].
+    """
+    candidates: set[bytes] = set()
+    for length in candidate_lengths:
+        if length <= 0:
+            continue
+        if len(payload) == length + 1:
+            candidates.add(bytes(payload[:-1]))
+    return candidates
+
+
+def _extract_after_frame_type(payload: bytes, frame_type: int, start: int) -> ExtractedEid | None:
+    """Extract an EID after the frame_type byte with optional hashed flags."""
+    remaining = payload[start:]
+    remaining_len = len(remaining)
+
+    if remaining_len in (21, 33) and remaining_len - 1 in FMDN_EID_CANDIDATE_LENGTHS:
+        eid_len = remaining_len - 1
+        return ExtractedEid(eid=remaining[:eid_len], frame_type=frame_type, hashed_flags=remaining[-1])
+
+    if remaining_len in FMDN_EID_CANDIDATE_LENGTHS:
+        return ExtractedEid(eid=remaining, frame_type=frame_type, hashed_flags=None)
+
+    return None
+
+
+def _extract_embedded_uuid(payload: bytes) -> ExtractedEid | None:
+    """Return an extracted EID when the FEAA UUID marker is embedded in the payload."""
+    idx = payload.find(_FHN_UUID_MARKER)
+    if idx == -1 or idx + 2 >= len(payload):
+        return None
+
+    candidate_frame_type = payload[idx + 2]
+    if candidate_frame_type not in _FHN_FRAME_TYPES:
+        return None
+
+    return _extract_after_frame_type(payload, candidate_frame_type, start=idx + 3)
+
+
+def _extract_eid_payload(payload: bytes) -> ExtractedEid | None:
+    """
+    Normalize a payload into a bare EID, accounting for optional frame and hashed flags bytes.
+
+    Supported shapes:
+    - EID only (20 or 32 bytes)
+    - [frame_type] + EID
+    - [frame_type] + EID + hashed_flags
+    - payload containing ... 0xAA 0xFE [frame_type] [EID] [hashed_flags?]
+    """
+    if not payload:
+        return None
+
+    if len(payload) in FMDN_EID_CANDIDATE_LENGTHS:
+        return ExtractedEid(eid=payload, frame_type=None, hashed_flags=None)
+
+    if payload[0] in _FHN_FRAME_TYPES:
+        extracted = _extract_after_frame_type(payload, frame_type=payload[0], start=1)
+        if extracted:
+            return extracted
+
+    embedded = _extract_embedded_uuid(payload)
+    if embedded:
+        return embedded
+
+    # Some sources may only append a hashed flag without a frame byte.
+    if len(payload) in (21, 33) and len(payload) - 1 in FMDN_EID_CANDIDATE_LENGTHS:
+        return ExtractedEid(eid=payload[:-1], frame_type=None, hashed_flags=payload[-1])
+
+    return None
+
+
+def _candidates_from_payload(
+    payload: bytes,
+    *,
+    mode: str,
+    candidate_lengths: Sequence[int],
+) -> set[bytes]:
+    """Produce a set of plausible EID candidates from a raw payload."""
+    if not payload:
+        return set()
+
+    candidates: set[bytes] = set()
+    extracted = _extract_eid_payload(payload)
+    frame_type = (
+        extracted.frame_type
+        if extracted is not None and extracted.frame_type is not None
+        else (payload[0] if payload else 0x00)
+    )
+    payload_len = len(payload)
+
+    # Non-auto modes should be deterministic and cheap:
+    # - strip_frame_20: first configured length from the normalized EID
+    # - strip_frame_all: normalized EID and its prefixes
+    # Auto mode may use broader heuristics (prefix + checksum-trim + sliding windows).
+
+    if extracted is not None:
+        base_eid = extracted.eid
+        if mode == FMDN_EID_FORMAT_STRIP_FRAME_20:
+            if candidate_lengths and len(base_eid) >= candidate_lengths[0]:
+                candidates.add(bytes(base_eid[: candidate_lengths[0]]))
+            else:
+                _log_malformed(mode, frame_type, payload_len, "short_after_frame")
+            if extracted.frame_type is None and len(base_eid) in candidate_lengths:
+                candidates.add(bytes(base_eid))
+        elif mode == FMDN_EID_FORMAT_STRIP_FRAME_ALL:
+            if not base_eid:
+                _log_malformed(mode, frame_type, payload_len, "no_payload_after_frame")
+            else:
+                candidates.add(bytes(base_eid))
+                candidates.update(_prefix_candidates(base_eid, candidate_lengths))
+        else:
+            candidates.add(bytes(base_eid))
+            candidates.update(_prefix_candidates(base_eid, candidate_lengths))
+            candidates.update(_auto_trim_checksum_candidates(base_eid, candidate_lengths))
+            candidates.update(_sliding_window_candidates(base_eid, candidate_lengths))
+    else:
+        _log_malformed(mode, frame_type, payload_len, "frame_type")
+        if payload and payload[0] in _FHN_FRAME_TYPES:
+            after_frame = payload[1:]
+            if mode == FMDN_EID_FORMAT_STRIP_FRAME_20:
+                if candidate_lengths and len(after_frame) >= candidate_lengths[0]:
+                    candidates.add(bytes(after_frame[: candidate_lengths[0]]))
+                else:
+                    _log_malformed(mode, frame_type, payload_len, "short_after_frame")
+            elif mode == FMDN_EID_FORMAT_STRIP_FRAME_ALL:
+                if not after_frame:
+                    _log_malformed(mode, frame_type, payload_len, "no_payload_after_frame")
+                else:
+                    candidates.add(bytes(after_frame))
+                    candidates.update(_prefix_candidates(after_frame, candidate_lengths))
+            else:
+                candidates.update(_prefix_candidates(after_frame, candidate_lengths))
+                candidates.update(_auto_trim_checksum_candidates(after_frame, candidate_lengths))
+                candidates.update(_sliding_window_candidates(after_frame, candidate_lengths))
+        elif mode == FMDN_EID_FORMAT_STRIP_FRAME_20:
+            if candidate_lengths:
+                if len(payload) >= candidate_lengths[0] + 1:
+                    candidates.add(bytes(payload[1 : 1 + candidate_lengths[0]]))
+                elif len(payload) >= candidate_lengths[0]:
+                    candidates.add(bytes(payload[: candidate_lengths[0]]))
+        elif mode == FMDN_EID_FORMAT_STRIP_FRAME_ALL:
+            candidates.add(bytes(payload))
+            candidates.update(_prefix_candidates(payload, candidate_lengths))
+        else:
+            candidates.update(_prefix_candidates(payload, candidate_lengths))
+            candidates.update(_auto_trim_checksum_candidates(payload, candidate_lengths))
+            candidates.update(_sliding_window_candidates(payload, candidate_lengths))
+
+    if not candidates:
+        _log_malformed(mode, frame_type, payload_len, "no_candidates")
+        return set()
+
+    _log_candidates(mode, frame_type, payload_len, len(candidates))
+    return candidates
+
+
+def extract_fmdn_eids(
+    service_data: Mapping[str | int, Any],
+    *,
+    mode: str | None = None,
+    candidate_lengths: Iterable[int] | None = None,
+) -> set[bytes]:
+    """
+    Extract all plausible ephemeral identifier candidates from FMDN service data.
+
+    Modes:
+    - strip_frame_20: prefer windows after the frame byte using the first configured length.
+    - strip_frame_all: prefer windows after the frame byte using all configured lengths.
+    - auto: generate windows across payloads with and without the frame byte present.
+    """
+    mode_value = DEFAULT_FMDN_EID_FORMAT if mode is None else str(mode)
+    mode = _normalized_mode(mode_value)
+    _log_mode(mode)
+
+    lengths: tuple[int, ...] = tuple(candidate_lengths or FMDN_EID_CANDIDATE_LENGTHS)
+    candidates: set[bytes] = set()
+
     for service_uuid, payload in service_data.items():
         if not is_fmdn_service_uuid(service_uuid):
             continue
-
         if not isinstance(payload, (bytes, bytearray, memoryview)):
             continue
-        if len(payload) < 2:
-            continue
 
-        frame_type = payload[0]
-        if frame_type != 0x40:
-            continue
-        if len(payload) >= 21:
-            return bytes(payload[1:21])
+        payload_bytes = bytes(payload)
+        payload_len = len(payload_bytes)
+        _LOGGER.debug("Evaluating FMDN payload len=%d for candidates", payload_len)
 
-    return None
+        candidates.update(_candidates_from_payload(payload_bytes, mode=mode, candidate_lengths=lengths))
+
+    return candidates
+
+
+def extract_fmdn_eid(service_data: Mapping[str | int, Any], mode: str | None = None) -> bytes | None:
+    """
+    Legacy helper returning the first extracted EID candidate, if any.
+
+    Prefer :func:`extract_fmdn_eids` for multi-candidate extraction.
+    """
+    candidates = extract_fmdn_eids(service_data, mode=mode)
+    if not candidates:
+        return None
+    return next(iter(candidates))

--- a/custom_components/bermuda/manifest.json
+++ b/custom_components/bermuda/manifest.json
@@ -10,6 +10,7 @@
   "codeowners": ["@agittins"],
   "config_flow": true,
   "dependencies": ["bluetooth_adapters", "device_tracker", "private_ble_device"],
+  "after_dependencies": ["googlefindmy"],
   "documentation": "https://github.com/agittins/bermuda",
   "integration_type": "device",
   "iot_class": "calculated",

--- a/tests/const.py
+++ b/tests/const.py
@@ -27,6 +27,8 @@ MOCK_OPTIONS_GLOBALS = {
     custom_components.bermuda.const.CONF_SMOOTHING_SAMPLES: 20,
     custom_components.bermuda.const.CONF_ATTENUATION: 3.0,
     custom_components.bermuda.const.CONF_REF_POWER: -55.0,
+    custom_components.bermuda.const.CONF_FMDN_MODE: custom_components.bermuda.const.DEFAULT_FMDN_MODE,
+    custom_components.bermuda.const.CONF_FMDN_EID_FORMAT: custom_components.bermuda.const.DEFAULT_FMDN_EID_FORMAT,
 }
 
 MOCK_OPTIONS_DEVICES = {

--- a/tests/test_bermuda_advert.py
+++ b/tests/test_bermuda_advert.py
@@ -6,6 +6,14 @@ import pytest
 from unittest.mock import MagicMock, patch
 from custom_components.bermuda.bermuda_advert import BermudaAdvert
 from custom_components.bermuda.bermuda_device import BermudaDevice
+from custom_components.bermuda.const import (
+    CONF_ATTENUATION,
+    CONF_MAX_VELOCITY,
+    CONF_REF_POWER,
+    CONF_RSSI_OFFSETS,
+    CONF_SMOOTHING_SAMPLES,
+)
+from custom_components.bermuda.util import normalize_mac
 from bleak.backends.scanner import AdvertisementData
 
 
@@ -13,7 +21,7 @@ from bleak.backends.scanner import AdvertisementData
 def mock_parent_device():
     """Fixture for mocking the parent BermudaDevice."""
     device = MagicMock(spec=BermudaDevice)
-    device.address = "aa:bb:cc:dd:ee:ff"
+    device.address = normalize_mac("aa:bb:cc:dd:ee:ff")
     device.ref_power = -59
     device.name_bt_local_name = None
     device.name = "mock parent name"
@@ -24,13 +32,13 @@ def mock_parent_device():
 def mock_scanner_device():
     """Fixture for mocking the scanner BermudaDevice."""
     scanner = MagicMock(spec=BermudaDevice)
-    scanner.address = "11:22:33:44:55:66"
+    scanner.address = normalize_mac("11:22:33:44:55:66")
     scanner.name = "Mock Scanner"
     scanner.area_id = "server_room"
     scanner.area_name = "server room"
     scanner.is_remote_scanner = True
     scanner.last_seen = 0.0
-    scanner.stamps = {"AA:BB:CC:DD:EE:FF": 123.45}
+    scanner.stamps = {normalize_mac("aa:bb:cc:dd:ee:ff"): 123.45}
     scanner.async_as_scanner_get_stamp.return_value = 123.45
     return scanner
 
@@ -53,11 +61,11 @@ def mock_advertisement_data():
 def bermuda_advert(mock_parent_device, mock_advertisement_data, mock_scanner_device):
     """Fixture for creating a BermudaAdvert instance."""
     options = {
-        "CONF_RSSI_OFFSETS": {"11:22:33:44:55:66": 5},
-        "CONF_REF_POWER": -59,
-        "CONF_ATTENUATION": 2.0,
-        "CONF_MAX_VELOCITY": 3.0,
-        "CONF_SMOOTHING_SAMPLES": 5,
+        CONF_RSSI_OFFSETS: {normalize_mac("11:22:33:44:55:66"): 5},
+        CONF_REF_POWER: -59,
+        CONF_ATTENUATION: 2.0,
+        CONF_MAX_VELOCITY: 3.0,
+        CONF_SMOOTHING_SAMPLES: 5,
     }
     ba = BermudaAdvert(
         parent_device=mock_parent_device,
@@ -71,8 +79,8 @@ def bermuda_advert(mock_parent_device, mock_advertisement_data, mock_scanner_dev
 
 def test_bermuda_advert_initialization(bermuda_advert):
     """Test BermudaAdvert initialization."""
-    assert bermuda_advert.device_address == "aa:bb:cc:dd:ee:ff"
-    assert bermuda_advert.scanner_address == "11:22:33:44:55:66"
+    assert bermuda_advert.device_address == normalize_mac("aa:bb:cc:dd:ee:ff")
+    assert bermuda_advert.scanner_address == normalize_mac("11:22:33:44:55:66")
     assert bermuda_advert.ref_power == -59
     assert bermuda_advert.stamp == 123.45
     assert bermuda_advert.rssi == -70
@@ -122,11 +130,11 @@ def test_to_dict(bermuda_advert):
     """Test to_dict method."""
     advert_dict = bermuda_advert.to_dict()
     assert isinstance(advert_dict, dict)
-    assert advert_dict["device_address"] == "aa:bb:cc:dd:ee:ff"
-    assert advert_dict["scanner_address"] == "11:22:33:44:55:66"
+    assert advert_dict["device_address"] == normalize_mac("aa:bb:cc:dd:ee:ff")
+    assert advert_dict["scanner_address"] == normalize_mac("11:22:33:44:55:66")
 
 
 def test_repr(bermuda_advert):
     """Test __repr__ method."""
     repr_str = repr(bermuda_advert)
-    assert repr_str == "aa:bb:cc:dd:ee:ff__Mock Scanner"
+    assert repr_str == f"{normalize_mac('aa:bb:cc:dd:ee:ff')}__Mock Scanner"

--- a/tests/test_bermuda_device.py
+++ b/tests/test_bermuda_device.py
@@ -6,14 +6,33 @@ import pytest
 from unittest.mock import MagicMock, patch
 from homeassistant.components.bluetooth import BaseHaScanner, BaseHaRemoteScanner
 from custom_components.bermuda.bermuda_device import BermudaDevice
-from custom_components.bermuda.const import ICON_DEFAULT_AREA, ICON_DEFAULT_FLOOR
+from custom_components.bermuda.const import (
+    CONF_ATTENUATION,
+    CONF_MAX_VELOCITY,
+    CONF_REF_POWER,
+    CONF_RSSI_OFFSETS,
+    CONF_SMOOTHING_SAMPLES,
+    DEFAULT_ATTENUATION,
+    DEFAULT_MAX_VELOCITY,
+    DEFAULT_REF_POWER,
+    DEFAULT_SMOOTHING_SAMPLES,
+    ICON_DEFAULT_AREA,
+    ICON_DEFAULT_FLOOR,
+)
+from custom_components.bermuda.util import normalize_mac
 
 
 @pytest.fixture
 def mock_coordinator():
     """Fixture for mocking BermudaDataUpdateCoordinator."""
     coordinator = MagicMock()
-    coordinator.options = {}
+    coordinator.options = {
+        CONF_ATTENUATION: DEFAULT_ATTENUATION,
+        CONF_REF_POWER: DEFAULT_REF_POWER,
+        CONF_MAX_VELOCITY: DEFAULT_MAX_VELOCITY,
+        CONF_SMOOTHING_SAMPLES: DEFAULT_SMOOTHING_SAMPLES,
+        CONF_RSSI_OFFSETS: {},
+    }
     coordinator.hass_version_min_2025_4 = True
     return coordinator
 
@@ -50,7 +69,7 @@ def bermuda_scanner(mock_coordinator):
 
 def test_bermuda_device_initialization(bermuda_device):
     """Test BermudaDevice initialization."""
-    assert bermuda_device.address == "aa:bb:cc:dd:ee:ff"
+    assert bermuda_device.address == normalize_mac("aa:bb:cc:dd:ee:ff")
     assert bermuda_device.name.startswith("bermuda_")
     assert bermuda_device.area_icon == ICON_DEFAULT_AREA
     assert bermuda_device.floor_icon == ICON_DEFAULT_FLOOR
@@ -74,7 +93,7 @@ def test_async_as_scanner_update(bermuda_scanner, mock_scanner):
 def test_async_as_scanner_get_stamp(bermuda_scanner, mock_scanner, mock_remote_scanner):
     """Test async_as_scanner_get_stamp method."""
     bermuda_scanner.async_as_scanner_init(mock_scanner)
-    bermuda_scanner.stamps = {"AA:BB:CC:DD:EE:FF": 123.45}
+    bermuda_scanner.stamps = {normalize_mac("aa:bb:cc:dd:ee:ff"): 123.45}
 
     stamp = bermuda_scanner.async_as_scanner_get_stamp("AA:bb:CC:DD:EE:FF")
     assert stamp is None
@@ -116,7 +135,7 @@ def test_to_dict(bermuda_device):
     """Test to_dict method."""
     device_dict = bermuda_device.to_dict()
     assert isinstance(device_dict, dict)
-    assert device_dict["address"] == "aa:bb:cc:dd:ee:ff"
+    assert device_dict["address"] == normalize_mac("aa:bb:cc:dd:ee:ff")
 
 
 def test_repr(bermuda_device):

--- a/tests/test_fmdn_extract.py
+++ b/tests/test_fmdn_extract.py
@@ -1,0 +1,114 @@
+"""Tests for FMDN EID extraction helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.bermuda.const import (
+    FMDN_EID_FORMAT_AUTO,
+    FMDN_EID_FORMAT_STRIP_FRAME_20,
+    FMDN_EID_FORMAT_STRIP_FRAME_ALL,
+)
+from custom_components.bermuda.fmdn import extract_fmdn_eids, is_fmdn_service_uuid
+
+
+def test_is_fmdn_service_uuid_variants() -> None:
+    assert is_fmdn_service_uuid(0xFEAA) is True
+    assert is_fmdn_service_uuid("feaa") is True
+    assert is_fmdn_service_uuid("0xFEAA") is True
+    assert is_fmdn_service_uuid("0000feaa") is True
+    assert is_fmdn_service_uuid("0000feaa-0000-1000-8000-00805f9b34fb") is True
+    assert is_fmdn_service_uuid("0000abcd-0000-1000-8000-00805f9b34fb") is False
+
+
+def test_extract_strip_frame_20_returns_first_20_after_frame() -> None:
+    after_frame = bytes(range(1, 33))  # 32 bytes
+    payload = b"\x40" + after_frame
+    service_data = {0xFEAA: payload}
+
+    candidates = extract_fmdn_eids(service_data, mode=FMDN_EID_FORMAT_STRIP_FRAME_20)
+    assert candidates == {after_frame[:20]}
+
+
+def test_extract_strip_frame_all_includes_full_payload_and_prefixes() -> None:
+    after_frame = bytes(range(1, 33))  # 32 bytes
+    payload = b"\x40" + after_frame
+    service_data = {"0000feaa-0000-1000-8000-00805f9b34fb": payload}
+
+    candidates = extract_fmdn_eids(service_data, mode=FMDN_EID_FORMAT_STRIP_FRAME_ALL)
+    assert after_frame in candidates
+    assert after_frame[:20] in candidates
+    assert len(candidates) == 2
+
+
+def test_extract_auto_trims_checksum_and_builds_sliding_windows() -> None:
+    base = b"A" * 20
+    checksum = b"\x99"
+    after_frame = base + checksum  # 21 bytes
+    payload = b"\x40" + after_frame
+    service_data = {0xFEAA: payload}
+
+    candidates = extract_fmdn_eids(service_data, mode=FMDN_EID_FORMAT_AUTO)
+
+    assert base in candidates
+    assert all(len(candidate) in (20, 32) for candidate in candidates)
+
+
+def test_extract_ignores_non_fmdn_service_data() -> None:
+    service_data = {"0000abcd-0000-1000-8000-00805f9b34fb": b"\x40" + (b"\x01" * 21)}
+    candidates = extract_fmdn_eids(service_data, mode=FMDN_EID_FORMAT_AUTO)
+    assert candidates == set()
+
+
+@pytest.mark.parametrize(
+    ("mode_value", "expected_nonempty"),
+    [
+        (None, True),
+        ("unknown_mode", True),
+        (FMDN_EID_FORMAT_STRIP_FRAME_20, True),
+        (FMDN_EID_FORMAT_STRIP_FRAME_ALL, True),
+        (FMDN_EID_FORMAT_AUTO, True),
+    ],
+)
+def test_mode_defaults_and_fallback(mode_value: str | None, expected_nonempty: bool) -> None:
+    payload = b"\x40" + (b"\x11" * 32)
+    service_data = {0xFEAA: payload}
+    candidates = extract_fmdn_eids(service_data, mode=mode_value)
+    assert (len(candidates) > 0) is expected_nonempty
+
+
+def test_extract_accepts_32_byte_eid_only() -> None:
+    eid = bytes(range(32))
+    service_data = {0xFEAA: eid}
+
+    candidates = extract_fmdn_eids(service_data, mode=FMDN_EID_FORMAT_STRIP_FRAME_20)
+    assert eid in candidates
+
+
+def test_extract_trims_hashed_flags_after_frame() -> None:
+    eid = bytes(range(1, 21))
+    hashed_flags = b"\x99"
+    payload = b"\x41" + eid + hashed_flags
+    service_data = {0xFEAA: payload}
+
+    candidates = extract_fmdn_eids(service_data, mode=FMDN_EID_FORMAT_STRIP_FRAME_ALL)
+    assert eid in candidates
+    assert all(len(candidate) in (20, 32) for candidate in candidates)
+
+
+def test_extract_handles_32_byte_eid_with_frame_and_flags() -> None:
+    eid = bytes(range(1, 33))
+    payload = b"\x40" + eid + b"\x01"
+    service_data = {0xFEAA: payload}
+
+    candidates = extract_fmdn_eids(service_data, mode=FMDN_EID_FORMAT_AUTO)
+    assert eid in candidates
+
+
+def test_extract_from_embedded_uuid_marker() -> None:
+    eid = bytes(range(20))
+    payload = b"\x01\x02" + b"\xAA\xFE" + b"\x40" + eid + b"\xAA"
+    service_data = {0xFEAA: payload}
+
+    candidates = extract_fmdn_eids(service_data, mode=FMDN_EID_FORMAT_AUTO)
+    assert eid in candidates

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from math import floor
 
+import pytest
+
 from custom_components.bermuda import util
 
 
@@ -13,15 +15,30 @@ def test_mac_math_offset():
     assert util.mac_math_offset("aa:bb:cc:dd:ee:ef", 2) == "aa:bb:cc:dd:ee:f1"
     assert util.mac_math_offset("aa:bb:cc:dd:ee:ef", -3) == "aa:bb:cc:dd:ee:ec"
     assert util.mac_math_offset("aa:bb:cc:dd:ee:ff", 2) is None
-    assert util.mac_math_offset("clearly_not:a-mac_address", 2) == None
-    assert util.mac_math_offset(None, 4) == None
+    assert util.mac_math_offset("clearly_not:a-mac_address", 2) is None
+    assert util.mac_math_offset(None, 4) is None
 
 
-def test_mac_norm():
-    assert util.mac_norm("AA:bb:CC:88:Ff:00") == "aa:bb:cc:88:ff:00"
-    assert util.mac_norm("Not_exactly-a-MAC:address") == "not_exactly-a-mac:address"
-    assert util.mac_norm("aa_bb_CC_dd_ee_ff") == "aa:bb:cc:dd:ee:ff"
-    assert util.mac_norm("aa-77-CC-dd-ee-ff") == "aa:77:cc:dd:ee:ff"
+def test_normalize_mac_variants():
+    assert util.normalize_mac("AA:bb:CC:88:Ff:00") == "aa:bb:cc:88:ff:00"
+    assert util.normalize_mac("aa_bb_CC_dd_ee_ff") == "aa:bb:cc:dd:ee:ff"
+    assert util.normalize_mac("aa-77-CC-dd-ee-ff") == "aa:77:cc:dd:ee:ff"
+    assert util.normalize_mac("aabb.ccdd.eeff") == "aa:bb:cc:dd:ee:ff"
+    assert util.normalize_mac("AABBCCDDEEFF") == "aa:bb:cc:dd:ee:ff"
+
+
+def test_normalize_mac_rejects_non_mac():
+    with pytest.raises(ValueError):
+        util.normalize_mac("fmdn:abc123")
+
+
+def test_normalize_identifier_and_mac_dispatch():
+    assert util.normalize_identifier("AABBCCDDEEFF") == "aabbccddeeff"
+    assert util.normalize_identifier("12345678-1234-5678-9abc-def012345678_extra") == (
+        "12345678123456789abcdef012345678_extra"
+    )
+    assert util.normalize_address("AA-BB-CC-DD-EE-FF") == "aa:bb:cc:dd:ee:ff"
+    assert util.normalize_address("fmdn:Device-ID") == "fmdn:device-id"
 
 
 def test_mac_explode_formats():


### PR DESCRIPTION
## Summary
- add spec-aligned EID extraction that normalizes frame bytes, hashed flags, and embedded FEAA markers before resolution
- tighten FMDN candidate generation to avoid hashed-flag pollution while deduping log noise with the log_spam_less helper
- extend FMDN extraction tests to cover 20/32-byte EIDs, frame+flags variants, and embedded UUID payloads

## Testing
- python -m ruff check --fix
- python -m mypy --strict --install-types --non-interactive custom_components/bermuda/coordinator.py custom_components/bermuda/fmdn.py custom_components/bermuda/util.py
- python -m pytest --cov -q *(fails: repository enforces 100% coverage; suite reaches ~59%)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a7f56d0a88329b468948f03d86b15)