### PR TITLE
Normalize device registry connections and simplify FMDN options

### DIFF
--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -50,6 +50,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: BermudaConfigEntry) -> b
         _LOGGER.debug("Coordinator last update failed, rasing ConfigEntryNotReady")
         raise ConfigEntryNotReady
 
+    await coordinator.async_cleanup_device_registry_connections()
+
     try:
         await coordinator.async_refresh()
     except Exception as ex:  # noqa: BLE001

--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -27,8 +27,6 @@ from .const import (
     CONF_ATTENUATION,
     CONF_DEVICES,
     CONF_DEVTRACK_TIMEOUT,
-    CONF_FMDN_EID_FORMAT,
-    CONF_FMDN_MODE,
     CONF_MAX_RADIUS,
     CONF_MAX_VELOCITY,
     CONF_REF_POWER,
@@ -40,7 +38,6 @@ from .const import (
     CONF_UPDATE_INTERVAL,
     DEFAULT_ATTENUATION,
     DEFAULT_DEVTRACK_TIMEOUT,
-    DEFAULT_FMDN_EID_FORMAT,
     DEFAULT_FMDN_MODE,
     DEFAULT_MAX_RADIUS,
     DEFAULT_MAX_VELOCITY,
@@ -50,11 +47,7 @@ from .const import (
     DISTANCE_INFINITE,
     DOMAIN,
     DOMAIN_PRIVATE_BLE_DEVICE,
-    FMDN_EID_FORMAT_AUTO,
-    FMDN_EID_FORMAT_STRIP_FRAME_20,
-    FMDN_EID_FORMAT_STRIP_FRAME_ALL,
     FMDN_MODE_BOTH,
-    FMDN_MODE_RESOLVED_ONLY,
     FMDN_MODE_SOURCES_ONLY,
     METADEVICE_FMDN_DEVICE,
     METADEVICE_TYPE_FMDN_SOURCE,
@@ -212,17 +205,6 @@ class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
             self.options.update(user_input)
             return await self._update_options()
 
-        fmdn_mode_options = [
-            SelectOptionDict(value=FMDN_MODE_RESOLVED_ONLY, label="FMDN resolved devices only (default)"),
-            SelectOptionDict(value=FMDN_MODE_BOTH, label="FMDN resolved + sources (advanced)"),
-            SelectOptionDict(value=FMDN_MODE_SOURCES_ONLY, label="FMDN sources only (advanced)"),
-        ]
-        fmdn_eid_format_options = [
-            SelectOptionDict(value=FMDN_EID_FORMAT_STRIP_FRAME_20, label="Strip frame byte, first 20 bytes"),
-            SelectOptionDict(value=FMDN_EID_FORMAT_STRIP_FRAME_ALL, label="Strip frame byte, keep all payload bytes"),
-            SelectOptionDict(value=FMDN_EID_FORMAT_AUTO, label="Auto-trim trailing checksum if present"),
-        ]
-
         data_schema = {
             vol.Required(
                 CONF_MAX_RADIUS,
@@ -252,18 +234,6 @@ class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
                 CONF_REF_POWER,
                 default=self.options.get(CONF_REF_POWER, DEFAULT_REF_POWER),
             ): vol.Coerce(float),
-            vol.Required(
-                CONF_FMDN_MODE,
-                default=self.options.get(CONF_FMDN_MODE, DEFAULT_FMDN_MODE),
-            ): SelectSelector(
-                SelectSelectorConfig(options=fmdn_mode_options, multiple=False, mode=SelectSelectorMode.DROPDOWN)
-            ),
-            vol.Required(
-                CONF_FMDN_EID_FORMAT,
-                default=self.options.get(CONF_FMDN_EID_FORMAT, DEFAULT_FMDN_EID_FORMAT),
-            ): SelectSelector(
-                SelectSelectorConfig(options=fmdn_eid_format_options, multiple=False, mode=SelectSelectorMode.DROPDOWN)
-            ),
         }
 
         return self.async_show_form(step_id="globalopts", data_schema=vol.Schema(data_schema))
@@ -286,7 +256,7 @@ class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
         configured_devices = {
             normalize_address(address) for address in configured_devices_option if isinstance(address, str)
         }
-        fmdn_mode = self.options.get(CONF_FMDN_MODE, DEFAULT_FMDN_MODE)
+        fmdn_mode = DEFAULT_FMDN_MODE
 
         # Where we store the options before building the selector
         options_list = []

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -178,19 +178,11 @@ FMDN_MODE_RESOLVED_ONLY = "resolved_only"
 FMDN_MODE_SOURCES_ONLY = "sources_only"
 FMDN_MODE_BOTH = "both"
 DEFAULT_FMDN_MODE = FMDN_MODE_RESOLVED_ONLY
-DOCS[CONF_FMDN_MODE] = (
-    "FMDN exposure mode. resolved_only hides ephemeral sources and exposes only the resolved device; "
-    "sources_only surfaces only rotating source MACs; both exposes both."
-)
 CONF_FMDN_EID_FORMAT = "fmdn_eid_format"
 FMDN_EID_FORMAT_STRIP_FRAME_20 = "strip_frame_20"
 FMDN_EID_FORMAT_STRIP_FRAME_ALL = "strip_frame_all"
 FMDN_EID_FORMAT_AUTO = "auto"
-DEFAULT_FMDN_EID_FORMAT = FMDN_EID_FORMAT_STRIP_FRAME_20
-DOCS[CONF_FMDN_EID_FORMAT] = (
-    "FMDN EID extraction strategy. strip_frame_20 keeps the first 20 bytes after the 0x40 frame; "
-    "strip_frame_all keeps all bytes after the frame; auto trims a trailing checksum byte when present."
-)
+DEFAULT_FMDN_EID_FORMAT = FMDN_EID_FORMAT_AUTO
 FMDN_EID_CANDIDATE_LENGTHS: Final[tuple[int, ...]] = (20, 32)
 
 CONF_MAX_RADIUS, DEFAULT_MAX_RADIUS = "max_area_radius", 20

--- a/custom_components/bermuda/entity.py
+++ b/custom_components/bermuda/entity.py
@@ -115,10 +115,10 @@ class BermudaEntity(CoordinatorEntity):
         and also for matching up to device entries for other integrations.
         """
         # Match up our entity with any existing device entries.
-        # For scanners we use ethernet MAC, which looks like they are
-        # normally stored lowercased, otherwise we use our btmac, which
-        # seem to be stored uppercased.
-        # existing_device_id = None
+        # Canonicalization note:
+        # Bermuda uses util.normalize_mac() for MAC connections, which yields
+        # lower-case, colon-delimited MACs. Device registry connections must
+        # remain consistent to avoid duplicates that render identically in the UI.
         domain_name = DOMAIN
         model = None
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -27,8 +27,6 @@ MOCK_OPTIONS_GLOBALS = {
     custom_components.bermuda.const.CONF_SMOOTHING_SAMPLES: 20,
     custom_components.bermuda.const.CONF_ATTENUATION: 3.0,
     custom_components.bermuda.const.CONF_REF_POWER: -55.0,
-    custom_components.bermuda.const.CONF_FMDN_MODE: custom_components.bermuda.const.DEFAULT_FMDN_MODE,
-    custom_components.bermuda.const.CONF_FMDN_EID_FORMAT: custom_components.bermuda.const.DEFAULT_FMDN_EID_FORMAT,
 }
 
 MOCK_OPTIONS_DEVICES = {

--- a/tests/test_device_registry_cleanup.py
+++ b/tests/test_device_registry_cleanup.py
@@ -1,0 +1,72 @@
+"""Tests for device registry connection canonicalisation."""
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from pytest_homeassistant_custom_component.common import MockConfigEntry  # type: ignore[import-untyped]
+
+from custom_components.bermuda.const import DOMAIN
+from custom_components.bermuda.coordinator import BermudaDataUpdateCoordinator
+from custom_components.bermuda.util import normalize_mac
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def coordinator(hass: HomeAssistant) -> BermudaDataUpdateCoordinator:
+    """Create a minimal coordinator for registry cleanup tests."""
+    coordinator = BermudaDataUpdateCoordinator.__new__(BermudaDataUpdateCoordinator)
+    coordinator.hass = hass
+    coordinator.dr = dr.async_get(hass)
+    return coordinator
+
+
+async def test_cleanup_normalizes_and_deduplicates_connections(
+    coordinator: BermudaDataUpdateCoordinator, mock_bermuda_entry: MockConfigEntry
+) -> None:
+    """Normalize MACs and drop duplicate Bluetooth connections."""
+    registry = coordinator.dr
+
+    mac_upper = "AA:BB:CC:DD:EE:FF"
+    mac_lower = normalize_mac(mac_upper)
+
+    device = registry.async_get_or_create(
+        config_entry_id=mock_bermuda_entry.entry_id,
+        identifiers={(DOMAIN, "device-id")},
+        connections={
+            (dr.CONNECTION_BLUETOOTH, mac_upper),
+            (dr.CONNECTION_BLUETOOTH, mac_lower),
+            ("mac", "aa-bb-cc-dd-ee-ff"),
+        },
+    )
+
+    await coordinator.async_cleanup_device_registry_connections()
+
+    updated = registry.async_get(device.id)
+    assert updated is not None
+    assert updated.connections == {
+        (dr.CONNECTION_BLUETOOTH, mac_lower),
+        (dr.CONNECTION_NETWORK_MAC, mac_lower),
+    }
+
+
+async def test_cleanup_ignores_non_bermuda_devices(
+    coordinator: BermudaDataUpdateCoordinator, mock_bermuda_entry: MockConfigEntry
+) -> None:
+    """Ensure cleanup does not mutate devices outside the Bermuda domain."""
+    registry = coordinator.dr
+    original = registry.async_get_or_create(
+        config_entry_id=mock_bermuda_entry.entry_id,
+        identifiers={("other", "device-id")},
+        connections={
+            (dr.CONNECTION_BLUETOOTH, "AA:BB:CC:DD:EE:FF"),
+            ("mac", "AA:BB:CC:DD:EE:FF"),
+        },
+    )
+    original_connections = set(original.connections)
+
+    await coordinator.async_cleanup_device_registry_connections()
+
+    refreshed = registry.async_get(original.id)
+    assert refreshed is not None
+    assert refreshed.connections == original_connections


### PR DESCRIPTION
## Summary
- canonicalize Bermuda-owned device registry connections during setup to prevent duplicate Bluetooth MAC entries
- align scanner device registry lookups with normalized MAC candidates and clarify connection canonicalization in entity metadata
- remove FMDN mode/EID format options from the config flow, defaulting to automatic EID normalization before resolver handoff
- add regression coverage for connection cleanup behavior and legacy entries

## Testing
- python -m ruff check --fix
- python -m mypy --strict custom_components/bermuda/config_flow.py custom_components/bermuda/coordinator.py custom_components/bermuda/const.py custom_components/bermuda/bermuda_device.py tests/test_device_registry_cleanup.py tests/test_fmdn_resolution.py *(fails: existing strict-typing gaps in config_flow/test modules)*
- python -m pytest -k device_registry_cleanup -vv

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be1ae9a3c8329ba258e4b8077ae95)