### PR TITLE
Accept nowstamp in apply_scanner_selection

### DIFF
--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -670,7 +670,7 @@ class BermudaDevice(dict):
         Used to apply a "winning" scanner's data to the device for setting closest Area.
         """
         old_area = self.area_name
-        stamp_now = nowstamp or monotonic_time_coarse()
+        stamp_now = nowstamp if nowstamp is not None else monotonic_time_coarse()
         if (
             bermuda_advert is not None
             and bermuda_advert.area_id is not None
@@ -699,6 +699,7 @@ class BermudaDevice(dict):
                     old_area,
                     self.area_name,
                 )
+            self.last_seen = max(self.last_seen, stamp_now)
             return
 
         # Not close to any scanners, or closest scanner has timed out!

--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -1860,6 +1860,9 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator[Any]):
             cand_floor = getattr(candidate.scanner_device, "floor_id", None) if candidate else None
             return cur_floor is not None and cand_floor is not None and cur_floor != cand_floor
 
+        def _apply_selection(advert: BermudaAdvert | None) -> None:
+            device.apply_scanner_selection(advert, nowstamp=nowstamp)
+
         if winner is None:
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 fresh_adverts = [adv for adv in device.adverts.values() if _is_fresh(adv)]
@@ -1895,14 +1898,14 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator[Any]):
             device.pending_area_id = None
             device.pending_floor_id = None
             device.pending_streak = 0
-            device.apply_scanner_selection(None, nowstamp=nowstamp)
+            _apply_selection(None)
             return
 
         if device.area_advert is winner:
             device.pending_area_id = None
             device.pending_floor_id = None
             device.pending_streak = 0
-            device.apply_scanner_selection(winner, nowstamp=nowstamp)
+            _apply_selection(winner)
             return
 
         cross_floor = _resolve_cross_floor(device.area_advert, winner)
@@ -1912,7 +1915,7 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator[Any]):
             device.pending_area_id = None
             device.pending_floor_id = None
             device.pending_streak = 0
-            device.apply_scanner_selection(winner, nowstamp=nowstamp)
+            _apply_selection(winner)
             return
 
         if (
@@ -1929,10 +1932,10 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator[Any]):
             device.pending_area_id = None
             device.pending_floor_id = None
             device.pending_streak = 0
-            device.apply_scanner_selection(winner, nowstamp=nowstamp)
+            _apply_selection(winner)
         else:
             device.diag_area_switch = tests.sensortext()
-            device.apply_scanner_selection(device.area_advert, nowstamp=nowstamp)
+            _apply_selection(device.area_advert)
 
     def _refresh_scanners(self, force=False):
         """

--- a/tests/test_bermuda_device.py
+++ b/tests/test_bermuda_device.py
@@ -142,3 +142,18 @@ def test_repr(bermuda_device):
     """Test __repr__ method."""
     repr_str = repr(bermuda_device)
     assert repr_str == f"{bermuda_device.name} [{bermuda_device.address}]"
+
+
+def test_apply_scanner_selection_accepts_nowstamp(bermuda_device):
+    """Ensure apply_scanner_selection accepts and uses nowstamp."""
+    advert = MagicMock()
+    advert.area_id = "area-new"
+    advert.stamp = 100.0
+    advert.rssi_distance = 1.5
+    advert.rssi = -60.0
+    advert.scanner_device = MagicMock()
+
+    bermuda_device.apply_scanner_selection(advert, nowstamp=105.0)
+
+    assert bermuda_device.area_id == "area-new"
+    assert bermuda_device.last_seen == pytest.approx(105.0)


### PR DESCRIPTION
## Summary
- add a regression test to ensure `apply_scanner_selection` accepts `nowstamp` and propagates the timestamp
- update `BermudaDevice.apply_scanner_selection` to honor the provided `nowstamp` and refresh `last_seen`

## Testing
- python -m ruff check --fix
- python -m mypy --strict custom_components/bermuda/coordinator.py custom_components/bermuda/bermuda_device.py
- python -m pytest --cov -q *(fails: repository enforces 100% coverage on existing suite)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c9c2da1148329bdf066f37dc4ba50)