### PR TITLE
Restore sticky area selection stability

### DIFF
--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -677,11 +677,11 @@ class BermudaDevice(dict):
             and bermuda_advert.stamp >= stamp_now - AREA_MAX_AD_AGE
         ):
             distance = bermuda_advert.rssi_distance
+            # Allow stale distances from the previous winning advert to bridge gaps in broadcasts.
             if (
                 distance is None
                 and bermuda_advert is self.area_advert
                 and self.area_distance is not None
-                and bermuda_advert.stamp >= stamp_now - (AREA_MAX_AD_AGE * 1.5)
             ):
                 distance = self.area_distance
             # We found a winner

--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -1912,6 +1912,7 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator[Any]):
         streak_target = CROSS_FLOOR_STREAK if cross_floor else SAME_FLOOR_STREAK
 
         if device.area_advert is None and winner is not None:
+            # Bootstrap immediately when we have no area yet; don't wait for streak logic.
             device.pending_area_id = None
             device.pending_floor_id = None
             device.pending_streak = 0


### PR DESCRIPTION
## Summary
- Allow area distance selection to reuse the previous winning distance when no new measurement is available
- Keep the area selection bootstrap path applying the chosen scanner immediately instead of waiting for streaks

## Testing
- python -m ruff check --fix
- python -m mypy --strict --install-types --non-interactive custom_components/bermuda tests *(fails: existing type errors and missing annotations in repository)*
- python -m pytest --cov -q *(fails: coverage target set to 100% with current suite at ~70%)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d17d43b64832985d147fc685ac9a6)