### PR TITLE
Handle stale area adverts and distance retention

### DIFF
--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -38,6 +38,7 @@ from .const import (
     ADDR_TYPE_IBEACON,
     ADDR_TYPE_PRIVATE_BLE_DEVICE,
     AREA_MAX_AD_AGE,
+    AREA_RETENTION_SECONDS,
     BDADDR_TYPE_NOT_MAC48,
     BDADDR_TYPE_OTHER,
     BDADDR_TYPE_RANDOM_RESOLVABLE,
@@ -49,6 +50,7 @@ from .const import (
     CONF_FMDN_MODE,
     DEFAULT_DEVTRACK_TIMEOUT,
     DEFAULT_FMDN_MODE,
+    DISTANCE_RETENTION_SECONDS,
     DOMAIN,
     FMDN_MODE_BOTH,
     FMDN_MODE_RESOLVED_ONLY,
@@ -123,6 +125,10 @@ class BermudaDevice(dict):
         self.floor_name: str | None = None
         self.floor_icon: str = ICON_DEFAULT_FLOOR
         self.floor_level: str | None = None
+        self.area_state_stamp: float | None = None
+        self.area_distance_stamp: float | None = None
+        self.area_state_source: str | None = None
+        self.area_state_retained: bool = False
 
         self.zone: str = STATE_NOT_HOME  # STATE_HOME or STATE_NOT_HOME
         self.manufacturer: str | None = None
@@ -149,6 +155,7 @@ class BermudaDevice(dict):
         self.create_all_done: bool = False  # All platform entities are done and ready.
         self.last_seen: float = 0  # stamp from most recent scanner spotting. monotonic_time_coarse
         self.last_no_winner_log: float = 0.0
+        self.last_retained_log: float = 0.0
         self.diag_area_switch: str | None = None  # saves output of AreaTests
         self.adverts: dict[
             tuple[str, str], BermudaAdvert
@@ -662,6 +669,42 @@ class BermudaDevice(dict):
             # new measurement(s) immediately.
             self.ref_power_changed = monotonic_time_coarse()
 
+    def _area_state_age(self, stamp_now: float) -> float | None:
+        """Return the age of the last applied area selection."""
+        if self.area_state_stamp is None:
+            return None
+        return max(0.0, stamp_now - self.area_state_stamp)
+
+    def area_is_retained(self, *, stamp_now: float | None = None) -> bool:
+        """Indicate whether the published area is being retained past freshness."""
+        nowstamp = stamp_now if stamp_now is not None else monotonic_time_coarse()
+        age = self._area_state_age(nowstamp)
+        if age is None or age > AREA_RETENTION_SECONDS:
+            return False
+        return bool(self.area_state_retained or age > AREA_MAX_AD_AGE)
+
+    def area_state_metadata(self, *, stamp_now: float | None = None) -> dict[str, float | bool | str | None]:
+        """Expose metadata describing the freshness/retention of the published area."""
+        nowstamp = stamp_now if stamp_now is not None else monotonic_time_coarse()
+        area_age = self._area_state_age(nowstamp)
+        distance_age = None
+        if self.area_distance_stamp is not None:
+            distance_age = max(0.0, nowstamp - self.area_distance_stamp)
+        retention_remaining = None
+        if area_age is not None:
+            retention_remaining = AREA_RETENTION_SECONDS - area_age
+            if retention_remaining < 0:
+                retention_remaining = 0.0
+
+        return {
+            "last_good_area_age_s": area_age,
+            "last_good_distance_age_s": distance_age,
+            "area_is_stale": bool(area_age is not None and area_age > AREA_MAX_AD_AGE),
+            "area_retained": self.area_is_retained(stamp_now=nowstamp),
+            "area_retention_seconds_remaining": retention_remaining,
+            "area_source": self.area_state_source,
+        }
+
     def apply_scanner_selection(self, bermuda_advert: BermudaAdvert | None, *, nowstamp: float | None = None):
         """
         Given a BermudaAdvert entry, apply the distance and area attributes
@@ -671,42 +714,104 @@ class BermudaDevice(dict):
         """
         old_area = self.area_name
         stamp_now = nowstamp if nowstamp is not None else monotonic_time_coarse()
-        if (
-            bermuda_advert is not None
-            and bermuda_advert.area_id is not None
-            and bermuda_advert.stamp >= stamp_now - AREA_MAX_AD_AGE
-        ):
-            distance = bermuda_advert.rssi_distance
-            # Allow stale distances from the previous winning advert to bridge gaps in broadcasts.
-            if (
-                distance is None
-                and bermuda_advert is self.area_advert
+        if bermuda_advert is not None and bermuda_advert.area_id is not None:
+            distance = None
+            distance_stamp = None
+            same_area = self.area_advert is not None and (
+                bermuda_advert.area_id == self.area_advert.area_id
+                and getattr(bermuda_advert, "scanner_address", None)
+                == getattr(self.area_advert, "scanner_address", None)
+            )
+            advert_age = stamp_now - bermuda_advert.stamp if bermuda_advert.stamp is not None else None
+            if advert_age is not None and advert_age > AREA_MAX_AD_AGE:
+                _LOGGER.debug(
+                    "Applying stale area advert for %s: area=%s age=%.1fs",
+                    self.name,
+                    bermuda_advert.area_id,
+                    advert_age,
+                )
+            if bermuda_advert.rssi_distance is not None:
+                distance = bermuda_advert.rssi_distance
+                distance_stamp = bermuda_advert.stamp
+            elif (
+                same_area
                 and self.area_distance is not None
+                and (advert_age is None or advert_age <= AREA_MAX_AD_AGE)
+                and (
+                    self.area_distance_stamp is None
+                    or stamp_now - self.area_distance_stamp <= DISTANCE_RETENTION_SECONDS
+                )
             ):
                 distance = self.area_distance
+                distance_stamp = self.area_distance_stamp
+            elif same_area and self.area_distance is not None:
+                _LOGGER.debug(
+                    "Clearing distance for %s due to stale/no measurement "
+                    "(advert_age=%.1fs distance_age=%.1fs)",
+                    self.name,
+                    advert_age if advert_age is not None else -1,
+                    stamp_now - self.area_distance_stamp if self.area_distance_stamp else -1,
+                )
+
             # We found a winner
             self.area_advert = bermuda_advert
             self._update_area_and_floor(bermuda_advert.area_id)
             self.area_distance = distance
+            if distance is not None:
+                self.area_distance_stamp = distance_stamp or bermuda_advert.stamp or stamp_now
+            else:
+                self.area_distance_stamp = None
             self.area_rssi = bermuda_advert.rssi
             self.area_last_seen = self.area_name
             self.area_last_seen_id = self.area_id
             self.area_last_seen_icon = self.area_icon
-            if (old_area != self.area_name) and self.create_sensor:
+            self.area_state_stamp = bermuda_advert.stamp or stamp_now
+            self.area_state_source = getattr(bermuda_advert, "scanner_address", None)
+            self.area_state_retained = False
+            if (old_area != self.area_name or distance is None) and self.create_sensor:
                 _LOGGER.debug(
-                    "Device %s was in '%s', now '%s'",
+                    "Device %s was in '%s', now '%s'%s",
                     self.name,
                     old_area,
                     self.area_name,
+                    "" if distance is not None else " (distance cleared)",
                 )
             self.last_seen = max(self.last_seen, stamp_now)
             return
 
-        # Not close to any scanners, or closest scanner has timed out!
+        # Winner missing or stale: retain last known selection where possible.
+        last_good_age = self._area_state_age(stamp_now)
+        if last_good_age is not None and last_good_age <= AREA_RETENTION_SECONDS:
+            self.area_state_retained = True
+            if bermuda_advert is not None and self.area_state_source is None:
+                self.area_state_source = getattr(bermuda_advert, "scanner_address", None)
+            if stamp_now - self.last_retained_log > AREA_MAX_AD_AGE:
+                self.last_retained_log = stamp_now
+                _LOGGER.debug(
+                    "Retaining area for %s in %s (age=%.1fs, reason=%s)",
+                    self.name,
+                    self.area_name,
+                    last_good_age,
+                    "no_winner" if bermuda_advert is None else "stale_winner",
+                )
+            return
+
+        # Not close to any scanners, or closest scanner has timed out beyond retention.
+        if last_good_age is not None and stamp_now - self.last_retained_log > AREA_MAX_AD_AGE:
+            self.last_retained_log = stamp_now
+            _LOGGER.debug(
+                "Clearing retained area for %s after %.1fs silence",
+                self.name,
+                last_good_age,
+            )
         self.area_advert = None
         self._update_area_and_floor(None)
         self.area_distance = None
+        self.area_distance_stamp = None
         self.area_rssi = None
+        self.area_state_stamp = None
+        self.area_state_source = None
+        self.area_state_retained = False
 
         if (old_area != self.area_name) and self.create_sensor:
             _LOGGER.debug(

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -73,6 +73,11 @@ DISTANCE_INFINITE = 999  # arbitrary distance for infinite/unknown rssi range
 
 AREA_MAX_AD_AGE: Final = max(DISTANCE_TIMEOUT / 3, UPDATE_INTERVAL * 2)
 # Adverts older than this can not win an area contest.
+AREA_RETENTION_SECONDS: Final = 15 * 60
+# Keep the last known area/distance/floor for low-advertising trackers for a reasonable
+# window, independent of selection freshness.
+DISTANCE_RETENTION_SECONDS: Final = AREA_RETENTION_SECONDS
+# Distance is retained only when the winning scanner/area remain the same within this window.
 CROSS_FLOOR_MIN_HISTORY: Final = 8  # Minimum history length before cross-floor wins via historical checks.
 SAME_FLOOR_STREAK: Final = 1  # Consecutive wins needed before applying a same-floor switch.
 CROSS_FLOOR_STREAK: Final = 3  # Consecutive wins needed before applying a cross-floor switch.

--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -1584,11 +1584,17 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator[Any]):
             return advert is not None and advert.area_id is not None
 
         def _area_candidate(advert: BermudaAdvert | None) -> bool:
-            return _belongs(advert) and _is_fresh(advert) and _has_area(advert)
+            return _belongs(advert) and _has_area(advert)
 
         def _is_distance_contender(advert: BermudaAdvert | None) -> bool:
             effective_distance = _effective_distance(advert)
-            return _area_candidate(advert) and effective_distance is not None and effective_distance <= _max_radius
+            return (
+                _area_candidate(advert)
+                and advert is not None
+                and _is_fresh(advert)
+                and effective_distance is not None
+                and effective_distance <= _max_radius
+            )
 
         has_distance_contender = any(_is_distance_contender(advert) for advert in device.adverts.values())
 

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -231,6 +231,8 @@ class BermudaSensor(BermudaEntity, SensorEntity):
             attribs["floor_id"] = self._device.floor_id
             attribs["floor_name"] = self._device.floor_name
             attribs["floor_level"] = self._device.floor_level
+        if self.name in ["Area", "Floor", "Distance"]:
+            attribs.update(self._device.area_state_metadata())
         attribs["current_mac"] = current_mac
 
         return attribs

--- a/tests/test_area_selection.py
+++ b/tests/test_area_selection.py
@@ -19,6 +19,7 @@ from custom_components.bermuda.const import (
     DEFAULT_REF_POWER,
     DEFAULT_SMOOTHING_SAMPLES,
     CROSS_FLOOR_STREAK,
+    AREA_RETENTION_SECONDS,
 )
 from custom_components.bermuda.coordinator import BermudaDataUpdateCoordinator
 from custom_components.bermuda.bermuda_irk import BermudaIrkManager
@@ -85,12 +86,21 @@ def _make_advert(
         name=name,
         area_id=area_id,
         area_name=area_id,
+        scanner_address=scanner_device.address,
         rssi_distance=distance,
         rssi=rssi,
         stamp=stamp,
         scanner_device=scanner_device,
         hist_distance_by_interval=hist,
     )
+
+
+def _patch_monotonic_time(monkeypatch, current_time: list[float]) -> None:
+    """Patch monotonic_time_coarse across modules for deterministic timing."""
+    monkeypatch.setattr("bluetooth_data_tools.monotonic_time_coarse", lambda: current_time[0])
+    monkeypatch.setattr("custom_components.bermuda.coordinator.monotonic_time_coarse", lambda: current_time[0])
+    monkeypatch.setattr("custom_components.bermuda.bermuda_device.monotonic_time_coarse", lambda: current_time[0])
+    monkeypatch.setattr("tests.test_area_selection.monotonic_time_coarse", lambda: current_time[0])
 
 
 @pytest.fixture
@@ -352,8 +362,10 @@ def test_distance_fallback_requires_fresh_advert(coordinator: BermudaDataUpdateC
 
     device.apply_scanner_selection(stale_soft)
 
-    assert device.area_advert is None
+    assert device.area_id == "area-stale"
     assert device.area_distance is None
+    metadata = device.area_state_metadata(stamp_now=monotonic_time_coarse())
+    assert metadata["area_is_stale"] is True
 
 
 def test_legitimate_move_switches_to_better_challenger(coordinator: BermudaDataUpdateCoordinator):
@@ -482,6 +494,105 @@ def test_cross_floor_switch_requires_sustained_advantage(coordinator: BermudaDat
         coordinator._refresh_area_by_min_distance(device)
 
     assert device.area_advert is challenger
+
+
+def test_area_selection_retained_when_no_winner(monkeypatch, coordinator: BermudaDataUpdateCoordinator):
+    """Last known area should be retained across gaps shorter than the retention window."""
+    current_time = [1000.0]
+    _patch_monotonic_time(monkeypatch, current_time)
+    device = _configure_device(coordinator, "DD:EE:FF:00:11:22")
+
+    incumbent = _make_advert("inc", "area-stable", distance=2.5)
+    device.adverts = {"incumbent": incumbent}
+    coordinator._refresh_area_by_min_distance(device)
+
+    assert device.area_id == "area-stable"
+    current_time[0] += AREA_MAX_AD_AGE + 1
+    device.adverts = {}
+    coordinator._refresh_area_by_min_distance(device)
+
+    assert device.area_id == "area-stable"
+    metadata = device.area_state_metadata()
+    assert metadata["area_retained"] is True
+    assert metadata["last_good_area_age_s"] == pytest.approx(AREA_MAX_AD_AGE + 1)
+
+
+def test_retained_area_expires_after_window(monkeypatch, coordinator: BermudaDataUpdateCoordinator):
+    """Retained selections must eventually clear when the retention window elapses."""
+    current_time = [2000.0]
+    _patch_monotonic_time(monkeypatch, current_time)
+    device = _configure_device(coordinator, "EE:FF:00:11:22:33")
+
+    incumbent = _make_advert("inc", "area-once", distance=3.0)
+    device.adverts = {"incumbent": incumbent}
+    coordinator._refresh_area_by_min_distance(device)
+
+    current_time[0] += AREA_RETENTION_SECONDS + 5
+    device.adverts = {}
+    coordinator._refresh_area_by_min_distance(device)
+
+    assert device.area_id is None
+    metadata = device.area_state_metadata()
+    assert metadata["area_retained"] is False
+    assert metadata["last_good_area_age_s"] is None
+
+
+def test_fresh_advert_replaces_retained_state(monkeypatch, coordinator: BermudaDataUpdateCoordinator):
+    """A new contender should override retained state and reset staleness metadata."""
+    current_time = [3000.0]
+    _patch_monotonic_time(monkeypatch, current_time)
+    device = _configure_device(coordinator, "FF:00:11:22:33:44")
+
+    incumbent = _make_advert("inc", "area-old", distance=4.0)
+    device.adverts = {"incumbent": incumbent}
+    coordinator._refresh_area_by_min_distance(device)
+
+    current_time[0] += AREA_MAX_AD_AGE + 2
+    coordinator._refresh_area_by_min_distance(device)
+    assert device.area_state_metadata()["area_retained"] is True
+
+    challenger = _make_advert("chal", "area-new", distance=1.2)
+    device.adverts = {"incumbent": incumbent, "challenger": challenger}
+    coordinator._refresh_area_by_min_distance(device)
+
+    assert device.area_id == "area-new"
+    metadata = device.area_state_metadata()
+    assert metadata["area_retained"] is False
+    assert metadata["last_good_area_age_s"] == pytest.approx(0.0)
+
+
+def test_rssi_winner_does_not_keep_old_distance(coordinator: BermudaDataUpdateCoordinator):
+    """RSSI-only switches must not carry distance from the prior area."""
+    device = _configure_device(coordinator, "FD:FE:FF:00:11:22")
+
+    incumbent = _make_advert("inc", "area-old", distance=None, rssi=-70.0)
+    challenger = _make_advert("chal", "area-new", distance=None, rssi=-40.0)
+
+    device.area_advert = incumbent
+    device.area_distance = 3.0
+    device.adverts = {"inc": incumbent, "chal": challenger}
+
+    coordinator._refresh_area_by_min_distance(device)
+
+    assert device.area_advert is challenger
+    assert device.area_distance is None
+
+
+def test_stale_advert_still_applies_area(monkeypatch, coordinator: BermudaDataUpdateCoordinator):
+    """Initial stale adverts should still populate area/floor and mark stale metadata."""
+    current_time = [5000.0]
+    _patch_monotonic_time(monkeypatch, current_time)
+    device = _configure_device(coordinator, "AA:00:00:00:00:01")
+
+    stale_age = AREA_MAX_AD_AGE + 5
+    stale_advert = _make_advert("stale", "area-stale", distance=None, age=stale_age)
+    device.adverts = {"stale": stale_advert}
+
+    coordinator._refresh_area_by_min_distance(device)
+
+    assert device.area_id == "area-stale"
+    metadata = device.area_state_metadata(stamp_now=current_time[0])
+    assert metadata["area_is_stale"] is True
 
 
 def test_floor_level_populated_from_floor_registry(coordinator: BermudaDataUpdateCoordinator):


### PR DESCRIPTION
## Summary
- allow stale area adverts to apply while keeping distance retention bounded to the same scanner/area window
- add distance retention metadata and clearer stale/clearing logging in area application
- extend area selection coverage for stale publishes, retention expiry, and RSSI-only distance clearing

## Testing
- python -m ruff check --fix
- python -m mypy --strict custom_components/bermuda *(fails: existing untyped modules and missing annotations)*
- python -m pytest tests/test_area_selection.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d23ba9a688329a21ea20876fc147c)