### PR TITLE
feat: Show auto-configured devices in device selection options flow

### DIFF
--- a/custom_components/bermuda/translations/en.json
+++ b/custom_components/bermuda/translations/en.json
@@ -52,7 +52,7 @@
       },
       "selectdevices": {
         "title": "Select Devices",
-        "description": "Choose which devices you wish to track. If no devices appear below, then Bermuda is not seeing any data coming from Bluetooth scanners. Ensure you have an esphome ble_proxy device, Shelly devices with bluetooth proxy configured or a local bluetooth adaptor."
+        "description": "Choose which devices you wish to track. If no devices appear below, then Bermuda is not seeing any data coming from Bluetooth scanners. Ensure you have an esphome ble_proxy device, Shelly devices with bluetooth proxy configured or a local bluetooth adaptor.\n\nDevices marked with **[Auto: ...]** are automatically tracked via their respective integrations (Private BLE Device or Google Find My). These cannot be deselected here - manage them through their source integration."
       },
       "calibration1_global": {
         "title": "Calibration 1: Global",


### PR DESCRIPTION
Display devices that are automatically tracked via other integrations (Private BLE Device, Google Find My) in the Select Devices options flow. Previously these were hidden, which was confusing for users.

Changes:
- Add auto-configured devices to the selection list with [Auto: ...] labels
- Show them as pre-selected since they are actively being tracked
- Filter auto-configured devices from saved config (they're managed elsewhere)
- Update translation description to explain auto-configured devices