### PR TITLE
feat: Implement Two-Slope path loss model for distance estimation

### DIFF
--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -224,8 +224,48 @@ DOCS[CONF_MAX_VELOCITY] = (
 CONF_DEVTRACK_TIMEOUT, DEFAULT_DEVTRACK_TIMEOUT = "devtracker_nothome_timeout", 30
 DOCS[CONF_DEVTRACK_TIMEOUT] = "Timeout in seconds for setting devices as `Not Home` / `Away`."  # fmt: skip
 
-CONF_ATTENUATION, DEFAULT_ATTENUATION = "attenuation", 3
-DOCS[CONF_ATTENUATION] = "Factor for environmental signal attenuation."
+# Two-Slope Path Loss Model Constants
+# Based on research: PMC6165244, Wikipedia Path Loss models
+# Indoor BLE propagation has two distinct regions with different characteristics.
+
+PATH_LOSS_EXPONENT_NEAR: Final = 1.8
+"""
+Near-field path loss exponent for distances below the breakpoint.
+
+Scientifically derived value based on indoor BLE propagation research.
+In the near-field (Fresnel zone clear), signal propagation exhibits
+waveguiding effects with lower attenuation than free space (n=2.0).
+Typical indoor values range from 1.5-2.0. Value of 1.8 provides good
+accuracy for most residential/office environments.
+
+References:
+- PMC6165244: "Indoor Positioning Algorithm Based on Improved RSSI Distance Model"
+- Two-slope models show 4.9 dB std dev vs 17.2 dB for single-slope
+"""
+
+TWO_SLOPE_BREAKPOINT_METRES: Final = 6.0
+"""
+Breakpoint distance (metres) separating near-field and far-field regions.
+
+At this distance, the propagation model transitions from near-field
+(lower attenuation due to waveguiding) to far-field (higher attenuation
+due to multipath, obstacles, and environmental factors).
+
+Research indicates breakpoints typically occur at 5-10m for indoor BLE.
+Value of 6.0m provides good balance for residential environments.
+For large open spaces, consider 8-10m; for cluttered spaces, 4-5m.
+
+References:
+- Wikipedia: Two-ray ground-reflection model
+- Near-ground path loss measurements at 2.4 GHz
+"""
+
+CONF_ATTENUATION, DEFAULT_ATTENUATION = "attenuation", 3.5
+DOCS[CONF_ATTENUATION] = (
+    "Far-field path loss exponent for distances beyond ~6m. "
+    "Higher values = faster signal decay with distance. "
+    "Typical: 3.0 (open space) to 4.5 (cluttered/walls). Default: 3.5"
+)
 CONF_REF_POWER, DEFAULT_REF_POWER = "ref_power", -55.0
 DOCS[CONF_REF_POWER] = "Default RSSI for signal at 1 metre."
 

--- a/custom_components/bermuda/translations/en.json
+++ b/custom_components/bermuda/translations/en.json
@@ -36,7 +36,7 @@
           "devtracker_nothome_timeout": "Devtracker Timeout in seconds to consider a device as `Not Home`.",
           "update_interval": "Update Interval - How often (in seconds) to update sensor readings.",
           "smoothing_samples": "Smoothing Samples - how many samples to use for smoothing distance readings.",
-          "attenuation": "Attenuation - Environment attenuation factor for distance calculation/calibration.",
+          "attenuation": "Attenuation - Far-field path loss exponent (applies beyond ~6m). Typical: 3.0-4.5.",
           "ref_power": "Reference Power - Default rssi at 1 metre distance, for distance calibration.",
           "configured_devices": "Configured Devices - Select which Bluetooth devices or Beacons to track with Sensors."
         },
@@ -46,7 +46,7 @@
           "devtracker_nothome_timeout": "How quickly to mark device_tracker entities as `not_home` after we stop seeing advertisements. 30 to 300 seconds is probably good.",
           "update_interval": "Shortening distances will still trigger immediately, but increasing distances will be rate limited by this to reduce how much your database grows.",
           "smoothing_samples": "How many samples to average distance smoothing. Bigger numbers make for slower distance increases. Shortening distances are not affected. 10 or 20 seems good.",
-          "attenuation": "After setting ref_power at 1 metre, adjust attenuation so that other distances read correctly - more or less.",
+          "attenuation": "Two-Slope model: Near-field (<6m) uses fixed exponent 1.8. Adjust this far-field exponent for distances beyond 6m.",
           "ref_power": "Put your most-common beacon 1 metre (3.28') away from your most-common proxy / scanner. Adjust ref_power until the distance sensor shows a lowest (not average) distance of 1 metre."
         }
       },
@@ -66,7 +66,7 @@
         },
         "data_description": {
           "save_and_close": "After you are happy with the calibration, check this box and click Submit. Your changes will be saved, and you can proceed to the next calibration step. Leave this box un-checked while you adjust and test the settings.",
-          "attenuation": "After adjusting the above settings for 1m distance readings, move the device further away (for example 5 metres) and adust the attenuation until the calculated distances match the physical distance between the scanner and device. Click submit to see the new distance estimations.",
+          "attenuation": "Two-Slope model active: Near-field (<6m) uses scientifically-derived exponent 1.8. Move device beyond 6m and adjust this far-field exponent until distances match. Click submit to see updated estimations.",
           "ref_power": "To calibrate this setting, place the device 1 metre from the scanner, and adjust the value until the figures above reflect that 1m distance. Note that values will only recompute after clicking submit, and a more-negative number will result in a lower distance"
         }
       },

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -55,8 +55,22 @@ def test_mac_redact():
 
 
 def test_rssi_to_metres():
-    assert floor(util.rssi_to_metres(-50, -20, 2)) == 31
-    assert floor(util.rssi_to_metres(-80, -20, 2)) == 1000
+    """Test Two-Slope path loss model for RSSI to distance conversion.
+
+    The Two-Slope model uses:
+    - Near-field exponent 1.8 for distances < 6m
+    - User-configured far-field exponent for distances >= 6m
+    """
+    # Far-field test cases (distance > 6m breakpoint)
+    assert floor(util.rssi_to_metres(-50, -20, 2)) == 37
+    assert floor(util.rssi_to_metres(-80, -20, 2)) == 1196
+
+    # Near-field test case (distance < 6m)
+    # At ref_power=-55, rssi=-55 should give ~1m (near-field exponent 1.8)
+    assert 0.9 < util.rssi_to_metres(-55, -55, 3.5) < 1.1
+
+    # Test minimum distance floor (0.1m)
+    assert util.rssi_to_metres(-30, -55, 3.5) == 0.1  # Very strong signal
 
 
 def test_clean_charbuf():


### PR DESCRIPTION
Replaces single-slope log-distance model with scientifically-validated Two-Slope model that provides ~71% reduction in standard deviation (4.9 dB vs 17.2 dB according to PMC6165244 research).

Two-Slope model:
- Near-field (<6m): Uses fixed exponent 1.8 (Fresnel zone/waveguiding)
- Far-field (>=6m): Uses user-configured attenuation (default 3.5)

Changes:
- const.py: Add PATH_LOSS_EXPONENT_NEAR (1.8) and TWO_SLOPE_BREAKPOINT_METRES (6.0) with detailed scientific documentation
- util.py: Update rssi_to_metres() to use Two-Slope calculation
- translations/en.json: Update descriptions to explain new model
- test_util.py: Update tests for new expected values

The existing 'attenuation' config now controls far-field behavior only, giving users control over signal decay at longer distances while using research-based values for near-field accuracy.