### PR TITLE
fix: Reset Kalman filter and history when ref_power changes

### DIFF
--- a/custom_components/bermuda/bermuda_advert.py
+++ b/custom_components/bermuda/bermuda_advert.py
@@ -364,6 +364,12 @@ class BermudaAdvert(dict):
         # its own ref_power without need.
         if value != self.ref_power:
             self.ref_power = value
+            # Reset Kalman filter and distance history to avoid using stale values
+            # calculated with old ref_power (would cause incorrect distance calculations)
+            self.rssi_kalman.reset()
+            self.rssi_filtered = None
+            self.hist_distance.clear()
+            self.hist_distance_by_interval.clear()
             return self._update_raw_distance(False)
         return self.rssi_distance_raw
 


### PR DESCRIPTION
When the user calibrates a device's ref_power, the old Kalman-filtered RSSI values and distance history become invalid because they were calculated with the old ref_power.

Bug: After setting ref_power=-59dBm with current RSSI=-59dBm, distance showed 1.90m instead of 1m. This was because the Kalman filter still contained old RSSI values (e.g., -65dBm) which were being used with the new ref_power.

Fix: Reset rssi_kalman, rssi_filtered, hist_distance, and hist_distance_by_interval when ref_power changes, so the distance calculation starts fresh with the new calibration.