### PR TITLE
feat: Add dwell time based dynamic stability margins

### DIFF
--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -97,6 +97,23 @@ CROSS_FLOOR_STREAK: Final = 6  # Consecutive wins needed before applying a cross
 INCUMBENT_MARGIN_PERCENT: Final = 0.08  # 8% closer required to challenge incumbent
 INCUMBENT_MARGIN_METERS: Final = 0.20  # OR 0.2m closer required (whichever is easier to meet)
 
+# Dwell time based stability - margin increases with time in area
+# This makes it harder to switch rooms the longer a device stays stationary
+DWELL_TIME_MOVING_SECONDS: Final = 120  # 0-2 min: recently moved, lower threshold
+DWELL_TIME_SETTLING_SECONDS: Final = 600  # 2-10 min: settling in, normal threshold
+# After SETTLING: stationary, higher threshold
+
+# Movement state constants
+MOVEMENT_STATE_MOVING: Final = "moving"  # Recently changed rooms
+MOVEMENT_STATE_SETTLING: Final = "settling"  # Been in room a while
+MOVEMENT_STATE_STATIONARY: Final = "stationary"  # Been in room long time
+
+# Stability margins for each movement state
+MARGIN_MOVING_PERCENT: Final = 0.05  # 5% - easier to switch when moving
+MARGIN_SETTLING_PERCENT: Final = 0.08  # 8% - normal threshold (same as base)
+MARGIN_STATIONARY_PERCENT: Final = 0.15  # 15% - harder to switch when stationary
+MARGIN_STATIONARY_METERS: Final = 0.30  # 0.3m - also increase absolute threshold
+
 # Physical RSSI Priority - prevents offset-boosted signals from winning over physically closer sensors
 MIN_DISTANCE: Final = 0.1  # Minimum distance in metres (prevents multiple sensors at "0m")
 CONF_USE_PHYSICAL_RSSI_PRIORITY = "use_physical_rssi_priority"

--- a/tests/test_area_selection_cross_floor_guard.py
+++ b/tests/test_area_selection_cross_floor_guard.py
@@ -6,7 +6,11 @@ from dataclasses import dataclass
 
 import pytest
 
-from custom_components.bermuda.const import CONF_MAX_RADIUS, CROSS_FLOOR_STREAK
+from custom_components.bermuda.const import (
+    CONF_MAX_RADIUS,
+    CROSS_FLOOR_STREAK,
+    MOVEMENT_STATE_STATIONARY,
+)
 from custom_components.bermuda.coordinator import BermudaDataUpdateCoordinator
 
 
@@ -80,6 +84,12 @@ class FakeDevice:
         # Co-visibility learning (stub for testing)
         self.co_visibility_stats: dict[str, dict[str, dict[str, int]]] = {}
         self.co_visibility_min_samples: int = 50
+        # Dwell time tracking (stub for testing)
+        self.area_changed_at: float = 0.0
+
+    def get_movement_state(self, *, stamp_now: float | None = None) -> str:
+        """Stub for movement state - returns stationary for tests (hardest to switch)."""
+        return MOVEMENT_STATE_STATIONARY
 
     def update_co_visibility(self, area_id: str, visible_scanners: set[str], all_scanners: set[str]) -> None:
         """Stub for co-visibility update - just track stats for testing."""


### PR DESCRIPTION
Implement movement state tracking to make room switching harder the longer a device stays in an area:

- MOVING (0-2 min): 5% margin - easier to switch when moving
- SETTLING (2-10 min): 8% margin - normal threshold
- STATIONARY (10+ min): 15% margin, 0.3m - harder when stationary

This reduces room flickering for stationary devices while still allowing quick room detection when actually moving.

Changes:
- Add movement state constants to const.py
- Add area_changed_at, get_movement_state(), get_dwell_time() to BermudaDevice
- Update coordinator to use dynamic stability margins based on movement state
- Update test fixtures for FakeDevice with movement state support