### PR TITLE
fix: Add missing get_absolute_rssi() method to AreaProfile

### DIFF
--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -1723,8 +1723,8 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator[Any]):
                 # Check if the scanner has an absolute RSSI profile for this area
                 abs_profile = area_profile.get_absolute_rssi(scanner_addr)
                 if abs_profile is not None:
-                    expected_rssi = abs_profile.get_estimate()
-                    rssi_variance = abs_profile.get_variance()
+                    expected_rssi = abs_profile.expected_rssi
+                    rssi_variance = abs_profile.variance
                     rssi_delta = abs(current_rssi - expected_rssi)
 
                     # Allow up to 3 standard deviations from expected

--- a/custom_components/bermuda/correlation/area_profile.py
+++ b/custom_components/bermuda/correlation/area_profile.py
@@ -234,6 +234,19 @@ class AreaProfile:
 
         return results
 
+    def get_absolute_rssi(self, scanner_addr: str) -> ScannerAbsoluteRssi | None:
+        """
+        Get the absolute RSSI profile for a specific scanner.
+
+        Args:
+            scanner_addr: MAC address of the scanner.
+
+        Returns:
+            ScannerAbsoluteRssi instance if it exists, None otherwise.
+
+        """
+        return self._absolute_profiles.get(scanner_addr)
+
     def get_absolute_z_scores(
         self,
         readings: dict[str, float],


### PR DESCRIPTION
The UKF single-scanner retention code was calling get_absolute_rssi() on AreaProfile and get_estimate()/get_variance() on ScannerAbsoluteRssi, but these methods did not exist.

- Add get_absolute_rssi(scanner_addr) method to AreaProfile class
- Fix coordinator to use expected_rssi and variance properties instead of non-existent get_estimate() and get_variance() methods

This fixes AttributeError in bluetooth callback when UKF area selection is enabled.