### PR TITLE
fix: Improve BLE tracking stability and button training effectiveness

### DIFF
--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -266,7 +266,7 @@ DOCS[CONF_MAX_VELOCITY] = (
 
 # FIX: Teleport Recovery - Number of consecutive velocity-blocked measurements
 # before accepting the new position anyway (self-healing mechanism)
-VELOCITY_TELEPORT_THRESHOLD: Final = 5
+VELOCITY_TELEPORT_THRESHOLD: Final = 10
 """
 Number of consecutive measurements blocked by MAX_VELOCITY before accepting anyway.
 
@@ -274,6 +274,13 @@ When a device physically moves to a new location (e.g., from Scanner A at 12m to
 Scanner B at 1m), the calculated velocity may exceed MAX_VELOCITY, causing all
 new readings to be rejected. This threshold allows the system to self-heal:
 after N consecutive blocks from the SAME scanner, accept the new position.
+
+FIX: Increased from 5 to 10 to reduce false teleport detections caused by BLE noise.
+With noisy RSSI values causing calculated velocities of 100+ m/s, a threshold of 5
+triggered too frequently, constantly resetting the distance history. This caused
+cross-floor protection (which requires history) to fail. A higher threshold gives
+the Kalman filter more time to stabilize while still allowing recovery within
+reasonable time (~10 seconds with 1 update/second).
 """
 
 CONF_DEVTRACK_TIMEOUT, DEFAULT_DEVTRACK_TIMEOUT = "devtracker_nothome_timeout", 30

--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -1714,7 +1714,7 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator[Any]):
             return False
 
         # Single-scanner retention: verify RSSI against trained profile
-        if can_retain_with_single_scanner:
+        if can_retain_with_single_scanner and current_area_id is not None:
             scanner_addr = next(iter(rssi_readings))
             current_rssi = rssi_readings[scanner_addr]
             area_profile = device_profiles.get(current_area_id)


### PR DESCRIPTION
Three fixes to address room flickering and button training issues:

1. VELOCITY_TELEPORT_THRESHOLD increased from 5 to 10
   - BLE signal noise causes calculated velocities of 100+ m/s
   - Threshold of 5 triggered too frequently, resetting distance history
   - Cross-floor protection requires history to function correctly
   - Higher threshold gives Kalman filter time to stabilize

2. Added variance inflation to ScannerAbsoluteRssi.update_button()
   - Mirrors existing fix in ScannerPairCorrelation.update_button()
   - Allows button training to override converged auto-learning
   - Without this, thousands of auto-samples dominated button training

3. Fixed mypy type error in coordinator.py line 1717
   - Added explicit None check for current_area_id in condition
   - Satisfies mypy strict mode type checking