### PR TITLE
fix: Prevent duplicate device addresses in prune_list causing KeyError

### DIFF
--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -1203,7 +1203,8 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator[Any]):
                             # The source has been seen within the spec's limits, keep it.
                             metadevice_source_keepers.add(address)
                             _first = False
-                        else:
+                        # FIX: Prevent duplicates - device may appear in multiple metadevices
+                        elif address not in prune_list:
                             # It's too old to be an IRK, and otherwise we'll auto-detect it,
                             # so let's be rid of it.
                             prune_list.append(address)
@@ -1301,6 +1302,10 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator[Any]):
         # ###############################################
         # Prune_list is now ready to action. It contains no keepers, and is already
         # expanded if necessary to meet quota, as much as we can.
+
+        # FIX: Safety deduplication - devices may appear in multiple metadevices' sources
+        # which could cause the same address to be added multiple times
+        prune_list = list(dict.fromkeys(prune_list))  # Preserves order, removes duplicates
 
         # Prune the source devices
         for device_address in prune_list:

--- a/custom_components/bermuda/fmdn/integration.py
+++ b/custom_components/bermuda/fmdn/integration.py
@@ -412,7 +412,9 @@ class FmdnIntegration:
         if device.last_seen >= stamp_fmdn:
             return False
 
-        prune_list.append(device.address)
+        # FIX: Prevent duplicate entries - device may appear in multiple metadevices' sources
+        if device.address not in prune_list:
+            prune_list.append(device.address)
         return True
 
     @staticmethod


### PR DESCRIPTION
When a device appears in multiple metadevices' metadevice_sources, it could be added to the prune_list multiple times. This caused a KeyError when attempting to delete the same device address twice.

Changes:
- Add duplicate check in fmdn.prune_source() before appending
- Add duplicate check in coordinator metadevice loop (elif instead of else)
- Add safety deduplication using dict.fromkeys() before iterating prune_list