### PR TITLE
fix: Add scan_device method and guards for Resolution First hooks

### DIFF
--- a/tests/test_bermuda_device.py
+++ b/tests/test_bermuda_device.py
@@ -92,7 +92,9 @@ def test_async_as_scanner_update(bermuda_scanner: BermudaDevice, mock_scanner: M
     assert bermuda_scanner.last_seen > 0
 
 
-def test_async_as_scanner_get_stamp(bermuda_scanner: BermudaDevice, mock_scanner: MagicMock, mock_remote_scanner: MagicMock) -> None:
+def test_async_as_scanner_get_stamp(
+    bermuda_scanner: BermudaDevice, mock_scanner: MagicMock, mock_remote_scanner: MagicMock
+) -> None:
     """Test async_as_scanner_get_stamp method."""
     bermuda_scanner.async_as_scanner_init(mock_scanner)
     bermuda_scanner.stamps = {normalize_mac("aa:bb:cc:dd:ee:ff"): 123.45}

--- a/tests/test_fmdn_googlefindmy_compatibility.py
+++ b/tests/test_fmdn_googlefindmy_compatibility.py
@@ -94,9 +94,7 @@ class TestGoogleFindMyAPIContract:
         # canonical_id should be UUID-only (no colons as separators)
         canonical = eid_match.canonical_id
         # UUID format has dashes, not colons for separation
-        assert ":" not in canonical.replace("-", ""), (
-            "canonical_id should be UUID-only, not entry_id:uuid format"
-        )
+        assert ":" not in canonical.replace("-", ""), "canonical_id should be UUID-only, not entry_id:uuid format"
 
     def test_device_registry_identifier_formats(self) -> None:
         """Verify expected identifier formats from GoogleFindMy-HA.
@@ -122,9 +120,7 @@ class TestGoogleFindMyAPIContract:
             else:
                 extracted = identifier_value
 
-            assert extracted == expected_uuid, (
-                f"Failed to extract UUID from '{identifier_value}'"
-            )
+            assert extracted == expected_uuid, f"Failed to extract UUID from '{identifier_value}'"
 
 
 # =============================================================================
@@ -140,9 +136,7 @@ class TestCanonicalIdExtraction:
         clean_canonical_id = identity.canonical_id.split(":")[-1]
     """
 
-    def test_extracts_uuid_from_full_format(
-        self, fmdn_integration: FmdnIntegration
-    ) -> None:
+    def test_extracts_uuid_from_full_format(self, fmdn_integration: FmdnIntegration) -> None:
         """Extract UUID from entry_id:subentry_id:device_id format."""
         device = SimpleNamespace(
             identifiers={
@@ -154,9 +148,7 @@ class TestCanonicalIdExtraction:
 
         assert result == "68419b51-0000-2131-873b-fc411691d329"
 
-    def test_extracts_uuid_from_canonical_format(
-        self, fmdn_integration: FmdnIntegration
-    ) -> None:
+    def test_extracts_uuid_from_canonical_format(self, fmdn_integration: FmdnIntegration) -> None:
         """Extract UUID from entry_id:device_id format."""
         device = SimpleNamespace(
             identifiers={
@@ -168,9 +160,7 @@ class TestCanonicalIdExtraction:
 
         assert result == "68419b51-0000-2131-873b-fc411691d329"
 
-    def test_returns_uuid_directly_if_no_colons(
-        self, fmdn_integration: FmdnIntegration
-    ) -> None:
+    def test_returns_uuid_directly_if_no_colons(self, fmdn_integration: FmdnIntegration) -> None:
         """Return UUID as-is when already in simplest format."""
         device = SimpleNamespace(
             identifiers={
@@ -182,9 +172,7 @@ class TestCanonicalIdExtraction:
 
         assert result == "68419b51-0000-2131-873b-fc411691d329"
 
-    def test_ignores_non_googlefindmy_identifiers(
-        self, fmdn_integration: FmdnIntegration
-    ) -> None:
+    def test_ignores_non_googlefindmy_identifiers(self, fmdn_integration: FmdnIntegration) -> None:
         """Only process identifiers from googlefindmy domain."""
         device = SimpleNamespace(
             identifiers={
@@ -197,9 +185,7 @@ class TestCanonicalIdExtraction:
 
         assert result == "68419b51-0000"
 
-    def test_returns_none_for_empty_identifiers(
-        self, fmdn_integration: FmdnIntegration
-    ) -> None:
+    def test_returns_none_for_empty_identifiers(self, fmdn_integration: FmdnIntegration) -> None:
         """Return None when no googlefindmy identifiers found."""
         device = SimpleNamespace(identifiers=set())
 
@@ -221,9 +207,7 @@ class TestMetadeviceAddressConsistency:
     different addresses, duplicate metadevices will be created!
     """
 
-    def test_canonical_id_preferred_over_device_id(
-        self, fmdn_integration: FmdnIntegration
-    ) -> None:
+    def test_canonical_id_preferred_over_device_id(self, fmdn_integration: FmdnIntegration) -> None:
         """format_metadevice_address should prefer canonical_id."""
         address = fmdn_integration.format_metadevice_address(
             device_id="920aa0336e9c8bcf58b6dada3a9c68cb",
@@ -234,9 +218,7 @@ class TestMetadeviceAddressConsistency:
         assert "68419b51-0000-2131-873b-fc411691d329" in address
         assert "920aa0336e9c8bcf58b6dada3a9c68cb" not in address
 
-    def test_fallback_to_device_id_when_no_canonical(
-        self, fmdn_integration: FmdnIntegration
-    ) -> None:
+    def test_fallback_to_device_id_when_no_canonical(self, fmdn_integration: FmdnIntegration) -> None:
         """format_metadevice_address falls back to device_id."""
         address = fmdn_integration.format_metadevice_address(
             device_id="920aa0336e9c8bcf58b6dada3a9c68cb",
@@ -245,9 +227,7 @@ class TestMetadeviceAddressConsistency:
 
         assert "920aa0336e9c8bcf58b6dada3a9c68cb" in address
 
-    def test_entity_discovery_and_eid_resolution_produce_same_address(
-        self, fmdn_integration: FmdnIntegration
-    ) -> None:
+    def test_entity_discovery_and_eid_resolution_produce_same_address(self, fmdn_integration: FmdnIntegration) -> None:
         """
         Both discovery paths must produce identical metadevice addresses.
 
@@ -281,9 +261,7 @@ class TestMetadeviceAddressConsistency:
             "This will cause duplicate metadevices!"
         )
 
-    def test_address_format_is_normalized(
-        self, fmdn_integration: FmdnIntegration
-    ) -> None:
+    def test_address_format_is_normalized(self, fmdn_integration: FmdnIntegration) -> None:
         """Addresses should be normalized (lowercase, no special chars)."""
         address = fmdn_integration.format_metadevice_address(
             device_id=None,
@@ -315,6 +293,7 @@ class TestDeviceCongealment:
         """register_source must store fmdn_device_id for congealment."""
         # Create a source device
         from custom_components.bermuda.bermuda_device import BermudaDevice
+
         source_device = BermudaDevice(address="aa:bb:cc:dd:ee:ff", coordinator=mock_coordinator)
         mock_coordinator.devices["aa:bb:cc:dd:ee:ff"] = source_device
 
@@ -328,9 +307,7 @@ class TestDeviceCongealment:
         metadevice = BermudaDevice(address="fmdn:68419b51-0000-2131-873b-fc411691d329", coordinator=mock_coordinator)
         mock_coordinator._get_or_create_device = MagicMock(return_value=metadevice)  # type: ignore[method-assign]
 
-        metadevice_address = fmdn_integration.format_metadevice_address(
-            str(match.device_id), match.canonical_id
-        )
+        metadevice_address = fmdn_integration.format_metadevice_address(str(match.device_id), match.canonical_id)
         fmdn_integration.register_source(source_device, metadevice_address, match)
 
         # Verify fmdn_device_id is set (required for congealment)
@@ -341,6 +318,7 @@ class TestDeviceCongealment:
     ) -> None:
         """register_source must store fmdn_canonical_id."""
         from custom_components.bermuda.bermuda_device import BermudaDevice
+
         source_device = BermudaDevice(address="aa:bb:cc:dd:ee:ff", coordinator=mock_coordinator)
         mock_coordinator.devices["aa:bb:cc:dd:ee:ff"] = source_device
 
@@ -352,9 +330,7 @@ class TestDeviceCongealment:
         metadevice = BermudaDevice(address="fmdn:68419b51-0000-2131-873b-fc411691d329", coordinator=mock_coordinator)
         mock_coordinator._get_or_create_device = MagicMock(return_value=metadevice)  # type: ignore[method-assign]
 
-        metadevice_address = fmdn_integration.format_metadevice_address(
-            str(match.device_id), match.canonical_id
-        )
+        metadevice_address = fmdn_integration.format_metadevice_address(str(match.device_id), match.canonical_id)
         fmdn_integration.register_source(source_device, metadevice_address, match)
 
         # Verify fmdn_canonical_id is set
@@ -473,9 +449,7 @@ class TestRegressions:
         # Should only appear once in prune_list!
         assert prune_list.count("aa:bb:cc:dd:ee:ff") == 1
 
-    def test_canonical_id_uuid_only_not_prefixed(
-        self, fmdn_integration: FmdnIntegration
-    ) -> None:
+    def test_canonical_id_uuid_only_not_prefixed(self, fmdn_integration: FmdnIntegration) -> None:
         """
         Regression test for duplicate metadevices due to ID format mismatch.
 
@@ -494,6 +468,6 @@ class TestRegressions:
         # Must be UUID-only, NOT "config_entry_abc:68419b51-..."
         assert extracted == "68419b51-0000-2131-873b-fc411691d329"
         assert "config_entry" not in extracted
-        assert extracted.count(":") == 0 or all(
-            len(part) <= 4 for part in extracted.split(":")
-        ), "Should be UUID format (dash-separated), not colon-prefixed"
+        assert extracted.count(":") == 0 or all(len(part) <= 4 for part in extracted.split(":")), (
+            "Should be UUID format (dash-separated), not colon-prefixed"
+        )

--- a/tests/test_fmdn_hook.py
+++ b/tests/test_fmdn_hook.py
@@ -316,9 +316,7 @@ class TestFmdnServiceUuidDetection:
     def test_service_data_without_fmdn_uuid(self) -> None:
         """Test detection when FMDN UUID is not present."""
         # Service data with some other UUID
-        service_data: Mapping[str | int, Any] = {
-            "00001800-0000-1000-8000-00805f9b34fb": b"\x01\x02\x03"
-        }
+        service_data: Mapping[str | int, Any] = {"00001800-0000-1000-8000-00805f9b34fb": b"\x01\x02\x03"}
 
         has_fmdn_data = SERVICE_UUID_FMDN in service_data
         assert has_fmdn_data is False

--- a/tests/test_physical_rssi_priority.py
+++ b/tests/test_physical_rssi_priority.py
@@ -216,9 +216,7 @@ class TestMinimumDistance:
 class TestFeatureFlagBehavior:
     """Tests for feature flag on/off behavior."""
 
-    def test_feature_flag_off_uses_timestamp_tiebreak(
-        self, coordinator: BermudaDataUpdateCoordinator
-    ) -> None:
+    def test_feature_flag_off_uses_timestamp_tiebreak(self, coordinator: BermudaDataUpdateCoordinator) -> None:
         """When feature is off, timestamp-based tie-breaking is used."""
         device = _configure_device(coordinator, "AA:BB:CC:DD:EE:01")
 
@@ -408,9 +406,7 @@ class TestPhysicalSignalPriority:
         # Physically close should stay - the "closer" distance is not credible
         assert device.area_advert is physically_close  # type: ignore[comparison-overlap]
 
-    def test_extreme_offset_scenario(
-        self, coordinator_with_rssi_priority: BermudaDataUpdateCoordinator
-    ) -> None:
+    def test_extreme_offset_scenario(self, coordinator_with_rssi_priority: BermudaDataUpdateCoordinator) -> None:
         """
         Extreme case: Sensor B appears at 0.4m through absurd offset,
         but Sensor A at 0.46m has much stronger physical signal.
@@ -494,9 +490,7 @@ class TestMedianRssi:
 class TestEdgeCases:
     """Edge cases and robustness tests."""
 
-    def test_none_rssi_handled_gracefully(
-        self, coordinator_with_rssi_priority: BermudaDataUpdateCoordinator
-    ) -> None:
+    def test_none_rssi_handled_gracefully(self, coordinator_with_rssi_priority: BermudaDataUpdateCoordinator) -> None:
         """Missing RSSI values should be handled without crashing."""
         device = _configure_device(coordinator_with_rssi_priority, "AA:BB:CC:DD:EE:08")
 
@@ -512,9 +506,7 @@ class TestEdgeCases:
         # Some outcome should be selected
         assert device.area_advert is not None
 
-    def test_both_rssi_none_uses_distance(
-        self, coordinator_with_rssi_priority: BermudaDataUpdateCoordinator
-    ) -> None:
+    def test_both_rssi_none_uses_distance(self, coordinator_with_rssi_priority: BermudaDataUpdateCoordinator) -> None:
         """When both have no RSSI, pure distance comparison should work."""
         device = _configure_device(coordinator_with_rssi_priority, "AA:BB:CC:DD:EE:09")
 

--- a/tests/test_rotating_mac_resolution.py
+++ b/tests/test_rotating_mac_resolution.py
@@ -469,8 +469,9 @@ class TestIrkResolution:
         # Step 2: Learn a valid IRK (16 bytes = 128 bits)
         # Note: This IRK won't actually match the random MAC since we're using
         # random data, but this tests the flow
-        test_irk = bytes([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
-                          0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00])
+        test_irk = bytes(
+            [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00]
+        )
 
         # add_irk will check all previously seen MACs against the new IRK
         matching_macs = coordinator.irk_manager.add_irk(test_irk)
@@ -505,9 +506,7 @@ class TestIrkResolution:
             # Result should exist (either matched IRK or unresolved type)
             assert result is not None, f"check_mac({mac}) should return a result"
 
-    def test_irk_callback_registration(
-        self, hass: HomeAssistant, coordinator: BermudaDataUpdateCoordinator
-    ) -> None:
+    def test_irk_callback_registration(self, hass: HomeAssistant, coordinator: BermudaDataUpdateCoordinator) -> None:
         """
         Test that IRK callbacks are properly handled.
 

--- a/tests/test_streak_no_increment_same_data.py
+++ b/tests/test_streak_no_increment_same_data.py
@@ -370,7 +370,9 @@ class TestStreakNoIncrementSameData:
         # Simulate multiple coordinator polls at t=1001, 1002, 1003 (same advert stamp)
         streak_increments = 0
         for poll_time in [BASE_TIME + 1, BASE_TIME + 2, BASE_TIME + 3]:
-            current_stamps = coordinator.area_selection._collect_current_stamps(cast("BermudaDevice", device), poll_time)
+            current_stamps = coordinator.area_selection._collect_current_stamps(
+                cast("BermudaDevice", device), poll_time
+            )
             has_new_data = coordinator.area_selection._has_new_advert_data(current_stamps, device.pending_last_stamps)
             if has_new_data:
                 streak_increments += 1
@@ -394,13 +396,17 @@ class TestStreakNoIncrementSameData:
         # First poll - same data (t=1000)
         advert = _make_advert(scanner, -60.0, BASE_TIME, 2.0)
         device.adverts[(DEVICE_ADDRESS, SCANNER_A)] = advert
-        current_stamps = coordinator.area_selection._collect_current_stamps(cast("BermudaDevice", device), BASE_TIME + 1)
+        current_stamps = coordinator.area_selection._collect_current_stamps(
+            cast("BermudaDevice", device), BASE_TIME + 1
+        )
         has_new_data_1 = coordinator.area_selection._has_new_advert_data(current_stamps, device.pending_last_stamps)
 
         # Second poll - new data (t=1003, new advertisement arrived)
         advert_new = _make_advert(scanner, -62.0, BASE_TIME + 3.0, 2.1)
         device.adverts[(DEVICE_ADDRESS, SCANNER_A)] = advert_new
-        current_stamps_new = coordinator.area_selection._collect_current_stamps(cast("BermudaDevice", device), BASE_TIME + 4)
+        current_stamps_new = coordinator.area_selection._collect_current_stamps(
+            cast("BermudaDevice", device), BASE_TIME + 4
+        )
         has_new_data_2 = coordinator.area_selection._has_new_advert_data(current_stamps_new, device.pending_last_stamps)
 
         # First poll should not detect new data


### PR DESCRIPTION
Implements user-suggested improvements for the Resolution First pattern:

1. Added `scan_device(address)` method to BermudaIrkManager
   - Wraps `check_mac()` with better feedback
   - Returns (matched: bool, result: bytes) tuple
   - Logs IRK matches and RPA status for debugging
   - Fires callbacks when matches are found (links device to metadevice)

2. Added defensive guards in `_async_gather_advert_data`:
   - `if self.irk_manager:` before IRK resolution
   - `if self.fmdn:` before FMDN resolution

3. Simplified FMDN service_data passing:
   - Pass `advertisementdata.service_data or {}` directly
   - Removed intermediate cast that wasn't needed

These changes ensure the identity resolution hooks are properly guarded and provide better visibility into what's happening during resolution.