### PR TITLE
fix: handle device identifiers with 3+ elements (upstream PR #727)

### DIFF
--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -120,7 +120,11 @@ async def async_remove_config_entry_device(
     """Implements user-deletion of devices from device registry."""
     coordinator: BermudaDataUpdateCoordinator = config_entry.runtime_data.coordinator
     address = None
-    for domain, ident in device_entry.identifiers:
+    for identifier in device_entry.identifiers:
+        # Handle variable-length identifiers (some integrations like HomeKit use 3+ elements)
+        if len(identifier) < 2:
+            continue
+        domain, ident = identifier[0], identifier[1]
         try:
             if domain == DOMAIN:
                 # the identifier should be the base device address, and

--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -495,7 +495,11 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator[Any]):
             if device_entry := self.dr.async_get(ev.data["device_id"]):
                 # Work out if it's a device that interests us and respond appropriately.
                 # First check identifiers for googlefindmy devices
-                for ident_type, ident_id in device_entry.identifiers:
+                # Handle variable-length identifiers (some integrations like HomeKit use 3+ elements)
+                for identifier in device_entry.identifiers:
+                    if len(identifier) < 2:
+                        continue
+                    ident_type, ident_id = identifier[0], identifier[1]
                     if ident_type == DOMAIN_GOOGLEFINDMY:
                         _LOGGER.debug("Trigger updating of FMDN Devices (googlefindmy)")
                         self._do_fmdn_device_init = True
@@ -509,7 +513,10 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator[Any]):
                         except KeyError:
                             pass
 
-                for conn_type, _conn_id in device_entry.connections:
+                for connection in device_entry.connections:
+                    if len(connection) < 2:
+                        continue
+                    conn_type = connection[0]
                     if conn_type == "private_ble_device":
                         _LOGGER.debug("Trigger updating of Private BLE Devices")
                         self._do_private_device_init = True


### PR DESCRIPTION
Some integrations (like HomeKit) use device identifiers with more than 2 elements (e.g., (domain, id, type)). The previous code assumed all identifiers were 2-tuples, causing ValueError when iterating.

Changes:
- __init__.py: async_remove_config_entry_device() now handles variable-length identifiers
- coordinator.py: Device registry update handler now handles variable-length identifiers
- coordinator.py: Connection iteration also made defensive for consistency

This fix mirrors upstream PR #727 (agittins/bermuda).

https://claude.ai/code/session_01LzNxUNSSL88K8KAb6tgdwJ