### PR TITLE
fix(ci): update release workflow to fix asset generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,11 +42,14 @@ jobs:
           zip bermuda.zip -r ./
 
       - name: 🔏 Sign release package
-        uses: sigstore/gh-action-sigstore-python@v3.0.1
+        uses: sigstore/gh-action-sigstore-python@v3.2.0
         with:
           inputs: "${{ env.BERMUDA_ROOT_DIR }}/bermuda.zip"
+          release-signing-artifacts: true
 
       - name: "Upload the ZIP file to the release"
-        uses: softprops/action-gh-release@v2.3.2
+        uses: softprops/action-gh-release@v2.5.0
         with:
-          files: ${{ env.BERMUDA_ROOT_DIR }}/bermuda.zip
+          files: |
+            ${{ env.BERMUDA_ROOT_DIR }}/bermuda.zip
+            ${{ env.BERMUDA_ROOT_DIR }}/bermuda.zip.sigstore.json


### PR DESCRIPTION
- Update sigstore/gh-action-sigstore-python from v3.0.1 to v3.2.0 (v3.0.1 has Python 3.14 incompatibility, v3.2.0 manages Python version internally for improved reliability)
- Explicitly set release-signing-artifacts: true to ensure sigstore bundles and signed source archives are uploaded to releases
- Include bermuda.zip.sigstore.json in the upload step as redundancy
- Update softprops/action-gh-release from v2.3.2 to v2.5.0

https://claude.ai/code/session_015U4Vg8TEomVWnYms9yTEiL