### PR TITLE
fix(ci): reorder release steps - upload before signing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,15 +41,13 @@ jobs:
           cd "${{ env.BERMUDA_ROOT_DIR }}"
           zip bermuda.zip -r ./
 
+      - name: "Upload the ZIP file to the release"
+        uses: softprops/action-gh-release@v2.5.0
+        with:
+          files: ${{ env.BERMUDA_ROOT_DIR }}/bermuda.zip
+
       - name: 🔏 Sign release package
         uses: sigstore/gh-action-sigstore-python@v3.2.0
         with:
           inputs: "${{ env.BERMUDA_ROOT_DIR }}/bermuda.zip"
           release-signing-artifacts: true
-
-      - name: "Upload the ZIP file to the release"
-        uses: softprops/action-gh-release@v2.5.0
-        with:
-          files: |
-            ${{ env.BERMUDA_ROOT_DIR }}/bermuda.zip
-            ${{ env.BERMUDA_ROOT_DIR }}/bermuda.zip.sigstore.json


### PR DESCRIPTION
The previous fix (PR #147) updated the sigstore action version but kept signing BEFORE upload. If the signing step fails for any reason, the entire job aborts and bermuda.zip never gets uploaded.

Fix: Move the ZIP upload step BEFORE sigstore signing. This ensures bermuda.zip is always available as a release asset. Sigstore signing is now a best-effort final step - it adds .sigstore.json bundles and signed source archives via release-signing-artifacts: true, but a signing failure no longer prevents the ZIP from being published.

https://claude.ai/code/session_015U4Vg8TEomVWnYms9yTEiL