### PR TITLE
fix(ci): revert release.yaml to upstream and fix hassfest-auto-fix ke…

### DIFF
--- a/.github/workflows/hassfest-auto-fix.yml
+++ b/.github/workflows/hassfest-auto-fix.yml
@@ -33,16 +33,29 @@ jobs:
       - name: Auto-format manifest.json
         if: steps.initial-check.outcome == 'failure'
         run: |
-          # Sort manifest.json keys alphabetically (HA standard)
+          # Sort manifest.json keys per hassfest requirement:
+          # "domain" first, "name" second, then remaining keys alphabetically
           for manifest in custom_components/*/manifest.json; do
             if [ -f "$manifest" ]; then
               echo "Formatting: $manifest"
               python3 -c "
           import json
+
           with open('$manifest', 'r') as f:
               data = json.load(f)
+
+          # hassfest requires: domain first, name second, then alphabetical
+          priority_keys = ['domain', 'name']
+          remaining_keys = sorted(k for k in data if k not in priority_keys)
+          ordered = {}
+          for k in priority_keys:
+              if k in data:
+                  ordered[k] = data[k]
+          for k in remaining_keys:
+              ordered[k] = data[k]
+
           with open('$manifest', 'w') as f:
-              json.dump(data, f, indent=2, sort_keys=True)
+              json.dump(ordered, f, indent=2)
               f.write('\n')
           "
             fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,13 +41,12 @@ jobs:
           cd "${{ env.BERMUDA_ROOT_DIR }}"
           zip bermuda.zip -r ./
 
-      - name: "Upload the ZIP file to the release"
-        uses: softprops/action-gh-release@v2.5.0
-        with:
-          files: ${{ env.BERMUDA_ROOT_DIR }}/bermuda.zip
-
       - name: 🔏 Sign release package
-        uses: sigstore/gh-action-sigstore-python@v3.2.0
+        uses: sigstore/gh-action-sigstore-python@v3.0.1
         with:
           inputs: "${{ env.BERMUDA_ROOT_DIR }}/bermuda.zip"
-          release-signing-artifacts: true
+
+      - name: "Upload the ZIP file to the release"
+        uses: softprops/action-gh-release@v2.3.2
+        with:
+          files: ${{ env.BERMUDA_ROOT_DIR }}/bermuda.zip


### PR DESCRIPTION
…y ordering

Root cause analysis revealed that the release workflow was never broken - all 10 release runs produced correct bermuda.zip + sigstore assets. The actual CI failures were from hassfest validation (manifest key ordering).

Changes:
- Revert release.yaml to match upstream (agittins/bermuda): restore original step order (sign then upload), revert action version bumps (sigstore v3.0.1, action-gh-release v2.3.2), remove unnecessary release-signing-artifacts option. PRs #147 and #148 misdiagnosed the problem and modified the wrong file.
- Fix hassfest-auto-fix.yml: replace sort_keys=True (pure alphabetical) with hassfest-compliant ordering (domain first, name second, then remaining keys alphabetically). The old sorting broke the manifest by moving domain and name out of their required positions.

https://claude.ai/code/session_01LxHWXWFnDS6SMMrKmbNaCX