### PR TITLE
fix(sensor): initialize rssi_distance_raw with default value

### DIFF
--- a/custom_components/bermuda/bermuda_advert.py
+++ b/custom_components/bermuda/bermuda_advert.py
@@ -159,7 +159,7 @@ class BermudaAdvert(dict[str, Any]):
         self.rssi: float | None = None
         self.tx_power: float | None = None
         self.rssi_distance: float | None = None
-        self.rssi_distance_raw: float
+        self.rssi_distance_raw: float | None = None  # Must have default, not just annotation
         self.stale_update_count = 0  # How many times we did an update but no new stamps were found.
         self.adaptive_timeout: float = AREA_MAX_AD_AGE_DEFAULT  # Calculated based on device's ad pattern
         self.hist_stamp: list[float] = []


### PR DESCRIPTION
Bug: The raw distance sensor showed "Unknown" while the filtered distance sensor showed a value (e.g., 8.59m) from the same scanner.

Root cause: `rssi_distance_raw: float` was only a type annotation without assignment. If `update_advertisement()` exited early (e.g., no new data from scanner), `_update_raw_distance()` was never called and the attribute didn't exist at all.

The raw sensor used `getattr(devscanner, "rssi_distance_raw", None)` which returned None for the non-existent attribute, displaying "Unknown".

Meanwhile, `rssi_distance` was set through a different code path in `calculate_data()` (Kalman filter smoothing), independent of the initialization issue.

Fix: Add explicit default value `float | None = None` to ensure the attribute always exists, matching the pattern used by `rssi_distance`.

https://claude.ai/code/session_01HKhCg8R3CUHG2vt3SXKW47