### PR TITLE
Fix scanner naming/area loss

### DIFF
--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -462,7 +462,7 @@ class BermudaDevice:
                     # ESPHome, Shelly
                     if scanner_devreg_mac is None or _is_better_entry(devreg_device, scanner_devreg_mac):
                         scanner_devreg_mac = devreg_device
-                        scanner_devreg_mac_address = conn[1]
+                        scanner_devreg_mac_address = conn[1].lower()
 
         devreg_count = len(devreg_seen_ids)
         if devreg_count not in (1, 2, 3):

--- a/tests/test_scanner_entry_preference.py
+++ b/tests/test_scanner_entry_preference.py
@@ -7,6 +7,8 @@ the classification loop must prefer entries with richer metadata (area_id,
 name_by_user) over entries without.
 """
 
+from __future__ import annotations
+
 from unittest.mock import MagicMock
 
 import pytest
@@ -180,3 +182,414 @@ class TestScannerEntryPreferenceScenarios:
         assert _is_better_entry(entry_b, entry_a) is False
         # Starting with A, C should NOT replace it
         assert _is_better_entry(entry_c, entry_a) is False
+
+
+def _make_entry_with_connections(
+    *,
+    area_id: str | None = None,
+    name_by_user: str | None = None,
+    name: str = "Default Name",
+    entry_id: str = "test_id",
+    connections: set[tuple[str, str]] | None = None,
+) -> dr.DeviceEntry:
+    """Create a mock DeviceEntry with specified metadata and connections."""
+    entry = MagicMock(spec=dr.DeviceEntry)
+    entry.area_id = area_id
+    entry.name_by_user = name_by_user
+    entry.name = name
+    entry.id = entry_id
+    entry.connections = connections or set()
+    return entry
+
+
+def _run_classification_loop(
+    entries: list[dr.DeviceEntry],
+) -> dict[str, object]:
+    """Simulate the inner classification loop from bermuda_device.py lines 452-465.
+
+    Returns a dict with the classification results:
+    - scanner_devreg_bt: selected BT DeviceEntry (or None)
+    - scanner_devreg_mac: selected MAC DeviceEntry (or None)
+    - scanner_devreg_bt_address: BT address (or None)
+    - scanner_devreg_mac_address: MAC address (or None)
+    """
+    scanner_devreg_bt: dr.DeviceEntry | None = None
+    scanner_devreg_mac: dr.DeviceEntry | None = None
+    scanner_devreg_bt_address: str | None = None
+    scanner_devreg_mac_address: str | None = None
+
+    for devreg_device in entries:
+        for conn in devreg_device.connections:
+            if conn[0] == "bluetooth":
+                if scanner_devreg_bt is None or _is_better_entry(devreg_device, scanner_devreg_bt):
+                    scanner_devreg_bt = devreg_device
+                    scanner_devreg_bt_address = conn[1].lower()
+            if conn[0] == "mac":
+                if scanner_devreg_mac is None or _is_better_entry(devreg_device, scanner_devreg_mac):
+                    scanner_devreg_mac = devreg_device
+                    scanner_devreg_mac_address = conn[1].lower()
+
+    return {
+        "scanner_devreg_bt": scanner_devreg_bt,
+        "scanner_devreg_mac": scanner_devreg_mac,
+        "scanner_devreg_bt_address": scanner_devreg_bt_address,
+        "scanner_devreg_mac_address": scanner_devreg_mac_address,
+    }
+
+
+def _run_downstream_selection(
+    result: dict[str, object],
+) -> dict[str, object]:
+    """Simulate the downstream priority logic from bermuda_device.py lines 493-542.
+
+    Takes the output of _run_classification_loop and returns selected values:
+    - area_id: final area_id (BT preferred, MAC fallback)
+    - entry_id: final entry_id
+    - unique_id: final unique_id (MAC preferred, BT fallback)
+    - address_ble_mac: BLE MAC address
+    - address_wifi_mac: WiFi MAC address
+    - name_devreg: selected device name
+    - name_by_user: selected user-given name
+    """
+    scanner_devreg_bt = result["scanner_devreg_bt"]
+    scanner_devreg_mac = result["scanner_devreg_mac"]
+    scanner_devreg_bt_address = result["scanner_devreg_bt_address"]
+    scanner_devreg_mac_address = result["scanner_devreg_mac_address"]
+
+    _area_id = None
+    _bt_name = None
+    _mac_name = None
+    _bt_name_by_user = None
+    _mac_name_by_user = None
+    _entry_id = None
+
+    if scanner_devreg_bt is not None:
+        _area_id = scanner_devreg_bt.area_id
+        _entry_id = scanner_devreg_bt.id
+        _bt_name_by_user = scanner_devreg_bt.name_by_user
+        _bt_name = scanner_devreg_bt.name
+    if scanner_devreg_mac is not None:
+        _area_id = _area_id or scanner_devreg_mac.area_id
+        _entry_id = _entry_id or scanner_devreg_mac.id
+        _mac_name = scanner_devreg_mac.name
+        _mac_name_by_user = scanner_devreg_mac.name_by_user
+
+    hascanner_source = "fallback_source"
+    unique_id = scanner_devreg_mac_address or scanner_devreg_bt_address or hascanner_source
+    address_ble_mac = scanner_devreg_bt_address or scanner_devreg_mac_address or hascanner_source
+    address_wifi_mac = scanner_devreg_mac_address
+
+    name_devreg = _mac_name or _bt_name
+    name_by_user = _bt_name_by_user or _mac_name_by_user
+
+    return {
+        "area_id": _area_id,
+        "entry_id": _entry_id,
+        "unique_id": unique_id,
+        "address_ble_mac": address_ble_mac,
+        "address_wifi_mac": address_wifi_mac,
+        "name_devreg": name_devreg,
+        "name_by_user": name_by_user,
+    }
+
+
+class TestDualConnectionDeviceEntry:
+    """Test Gap 1: DeviceEntry with both bluetooth and mac connections."""
+
+    def test_single_entry_with_both_connections(self) -> None:
+        """A single DeviceEntry with both bluetooth and mac should populate both slots.
+
+        ESPHome entries typically have a "mac" connection. In rare configurations,
+        a single entry might carry both connection types.
+        """
+        entry = _make_entry_with_connections(
+            area_id="kitchen_id",
+            name_by_user="Kitchen Proxy",
+            name="esphome-kitchen",
+            entry_id="dual_entry_id",
+            connections={
+                ("bluetooth", "AA:BB:CC:DD:EE:02"),
+                ("mac", "AA:BB:CC:DD:EE:00"),
+            },
+        )
+
+        result = _run_classification_loop([entry])
+
+        # Same entry should be selected for BOTH categories
+        assert result["scanner_devreg_bt"] is entry
+        assert result["scanner_devreg_mac"] is entry
+        assert result["scanner_devreg_bt_address"] == "aa:bb:cc:dd:ee:02"
+        assert result["scanner_devreg_mac_address"] == "aa:bb:cc:dd:ee:00"
+
+    def test_dual_connection_entry_vs_bt_only_entry(self) -> None:
+        """Dual-connection entry with area should win over BT-only entry without."""
+        bt_only = _make_entry_with_connections(
+            area_id=None,
+            name_by_user=None,
+            name="AA:BB:CC:DD:EE:02",
+            entry_id="bt_only_id",
+            connections={("bluetooth", "AA:BB:CC:DD:EE:02")},
+        )
+        dual = _make_entry_with_connections(
+            area_id="office_id",
+            name_by_user="Office Proxy",
+            name="esphome-office",
+            entry_id="dual_id",
+            connections={
+                ("bluetooth", "AA:BB:CC:DD:EE:00"),
+                ("mac", "AA:BB:CC:DD:EE:00"),
+            },
+        )
+
+        # Order: BT-only first, then dual
+        result = _run_classification_loop([bt_only, dual])
+        assert result["scanner_devreg_bt"] is dual
+        assert result["scanner_devreg_mac"] is dual
+
+        # Order: dual first, then BT-only
+        result = _run_classification_loop([dual, bt_only])
+        assert result["scanner_devreg_bt"] is dual
+        assert result["scanner_devreg_mac"] is dual
+
+    def test_mac_address_lowercased(self) -> None:
+        """MAC addresses from the mac connection type must be lowercased."""
+        entry = _make_entry_with_connections(
+            area_id="kitchen_id",
+            name="esphome-kitchen",
+            entry_id="entry_id",
+            connections={("mac", "AA:BB:CC:DD:EE:FF")},
+        )
+        result = _run_classification_loop([entry])
+        assert result["scanner_devreg_mac_address"] == "aa:bb:cc:dd:ee:ff"
+
+    def test_bt_address_lowercased(self) -> None:
+        """BT addresses from the bluetooth connection type must be lowercased."""
+        entry = _make_entry_with_connections(
+            area_id=None,
+            name="AA:BB:CC:DD:EE:FF",
+            entry_id="entry_id",
+            connections={("bluetooth", "AA:BB:CC:DD:EE:FF")},
+        )
+        result = _run_classification_loop([entry])
+        assert result["scanner_devreg_bt_address"] == "aa:bb:cc:dd:ee:ff"
+
+
+class TestDownstreamAreaNameSelection:
+    """Test Gap 2: Regression tests for downstream area_id/name selection logic.
+
+    The priority logic (lines 500-542 in bermuda_device.py) follows these rules:
+    - area_id: BT entry preferred, MAC entry as fallback (via `or`)
+    - entry_id: BT entry preferred, MAC entry as fallback (via `or`)
+    - name_devreg: MAC name preferred over BT name (via `or`)
+    - name_by_user: BT name_by_user preferred, MAC as fallback (via `or`)
+    - unique_id: MAC address preferred, BT as fallback
+    - address_ble_mac: BT address preferred, MAC as fallback
+    """
+
+    def test_bt_area_preferred_over_mac_area(self) -> None:
+        """BT entry's area_id should take priority over MAC entry's."""
+        bt_entry = _make_entry_with_connections(
+            area_id="bt_area_id",
+            name_by_user="BT Scanner",
+            name="bt-name",
+            entry_id="bt_entry_id",
+            connections={("bluetooth", "AA:BB:CC:DD:EE:02")},
+        )
+        mac_entry = _make_entry_with_connections(
+            area_id="mac_area_id",
+            name_by_user="MAC Scanner",
+            name="mac-name",
+            entry_id="mac_entry_id",
+            connections={("mac", "AA:BB:CC:DD:EE:00")},
+        )
+
+        result = _run_classification_loop([bt_entry, mac_entry])
+        downstream = _run_downstream_selection(result)
+
+        # BT area_id wins (primary)
+        assert downstream["area_id"] == "bt_area_id"
+        # BT entry_id wins (primary)
+        assert downstream["entry_id"] == "bt_entry_id"
+        # MAC name preferred for name_devreg (mac_name or bt_name)
+        assert downstream["name_devreg"] == "mac-name"
+        # BT name_by_user preferred (bt_name_by_user or mac_name_by_user)
+        assert downstream["name_by_user"] == "BT Scanner"
+
+    def test_mac_area_used_when_bt_has_none(self) -> None:
+        """MAC entry's area_id should be used when BT entry has no area."""
+        bt_entry = _make_entry_with_connections(
+            area_id=None,
+            name_by_user=None,
+            name="AA:BB:CC:DD:EE:02",
+            entry_id="bt_entry_id",
+            connections={("bluetooth", "AA:BB:CC:DD:EE:02")},
+        )
+        mac_entry = _make_entry_with_connections(
+            area_id="kitchen_id",
+            name_by_user="Kitchen Proxy",
+            name="esphome-kitchen",
+            entry_id="mac_entry_id",
+            connections={("mac", "AA:BB:CC:DD:EE:00")},
+        )
+
+        result = _run_classification_loop([bt_entry, mac_entry])
+        downstream = _run_downstream_selection(result)
+
+        # BT has no area → MAC area used as fallback
+        assert downstream["area_id"] == "kitchen_id"
+        # BT entry_id still wins (it's not None)
+        assert downstream["entry_id"] == "bt_entry_id"
+        # MAC name preferred
+        assert downstream["name_devreg"] == "esphome-kitchen"
+        # MAC name_by_user used as fallback
+        assert downstream["name_by_user"] == "Kitchen Proxy"
+
+    def test_address_priority_unique_id_prefers_mac(self) -> None:
+        """unique_id should prefer MAC address over BT address."""
+        bt_entry = _make_entry_with_connections(
+            area_id="area_id",
+            name="bt-name",
+            entry_id="bt_id",
+            connections={("bluetooth", "AA:BB:CC:DD:EE:02")},
+        )
+        mac_entry = _make_entry_with_connections(
+            area_id="area_id",
+            name="mac-name",
+            entry_id="mac_id",
+            connections={("mac", "AA:BB:CC:DD:EE:00")},
+        )
+
+        result = _run_classification_loop([bt_entry, mac_entry])
+        downstream = _run_downstream_selection(result)
+
+        # unique_id = mac_address or bt_address
+        assert downstream["unique_id"] == "aa:bb:cc:dd:ee:00"
+        # address_ble_mac = bt_address or mac_address
+        assert downstream["address_ble_mac"] == "aa:bb:cc:dd:ee:02"
+        # address_wifi_mac = mac_address only
+        assert downstream["address_wifi_mac"] == "aa:bb:cc:dd:ee:00"
+
+    def test_bt_only_no_mac_entry(self) -> None:
+        """When only a BT entry exists, all fields should come from BT."""
+        bt_entry = _make_entry_with_connections(
+            area_id="office_id",
+            name_by_user="Office Scanner",
+            name="bt-office",
+            entry_id="bt_entry_id",
+            connections={("bluetooth", "AA:BB:CC:DD:EE:02")},
+        )
+
+        result = _run_classification_loop([bt_entry])
+        downstream = _run_downstream_selection(result)
+
+        assert downstream["area_id"] == "office_id"
+        assert downstream["entry_id"] == "bt_entry_id"
+        assert downstream["name_devreg"] == "bt-office"
+        assert downstream["name_by_user"] == "Office Scanner"
+        # No MAC → BT address used for all
+        assert downstream["unique_id"] == "aa:bb:cc:dd:ee:02"
+        assert downstream["address_ble_mac"] == "aa:bb:cc:dd:ee:02"
+        assert downstream["address_wifi_mac"] is None
+
+    def test_mac_only_no_bt_entry(self) -> None:
+        """When only a MAC entry exists, all fields should come from MAC."""
+        mac_entry = _make_entry_with_connections(
+            area_id="kitchen_id",
+            name_by_user="Kitchen Proxy",
+            name="esphome-kitchen",
+            entry_id="mac_entry_id",
+            connections={("mac", "AA:BB:CC:DD:EE:00")},
+        )
+
+        result = _run_classification_loop([mac_entry])
+        downstream = _run_downstream_selection(result)
+
+        assert downstream["area_id"] == "kitchen_id"
+        assert downstream["entry_id"] == "mac_entry_id"
+        assert downstream["name_devreg"] == "esphome-kitchen"
+        assert downstream["name_by_user"] == "Kitchen Proxy"
+        assert downstream["unique_id"] == "aa:bb:cc:dd:ee:00"
+        assert downstream["address_ble_mac"] == "aa:bb:cc:dd:ee:00"
+        assert downstream["address_wifi_mac"] == "aa:bb:cc:dd:ee:00"
+
+    def test_three_entries_correct_downstream_selection(self) -> None:
+        """Full scenario: ESPHome + old BT + new BT auto-created entry.
+
+        ESPHome: "mac" connection, area=Kitchen, name_by_user="Kitchen Proxy"
+        Old BT: "bluetooth" connection (WiFi MAC), area=Kitchen, no name_by_user
+        New BT: "bluetooth" connection (BLE MAC), no area, no name_by_user
+
+        Expected: ESPHome wins for MAC, Old BT wins for BT (has area).
+        Downstream: area from BT (Kitchen), name from MAC (esphome-kitchen).
+        """
+        esphome_entry = _make_entry_with_connections(
+            area_id="kitchen_id",
+            name_by_user="Kitchen Proxy",
+            name="esphome-kitchen",
+            entry_id="esphome_id",
+            connections={("mac", "AA:BB:CC:DD:EE:00")},
+        )
+        bt_old = _make_entry_with_connections(
+            area_id="kitchen_id",
+            name_by_user=None,
+            name="old-bt",
+            entry_id="bt_old_id",
+            connections={("bluetooth", "AA:BB:CC:DD:EE:00")},
+        )
+        bt_new = _make_entry_with_connections(
+            area_id=None,
+            name_by_user=None,
+            name="AA:BB:CC:DD:EE:02",
+            entry_id="bt_new_id",
+            connections={("bluetooth", "AA:BB:CC:DD:EE:02")},
+        )
+
+        # Test all iteration orders — result should be the same
+        for order in [
+            [esphome_entry, bt_old, bt_new],
+            [bt_new, bt_old, esphome_entry],
+            [bt_old, bt_new, esphome_entry],
+            [bt_new, esphome_entry, bt_old],
+            [esphome_entry, bt_new, bt_old],
+            [bt_old, esphome_entry, bt_new],
+        ]:
+            result = _run_classification_loop(order)
+            downstream = _run_downstream_selection(result)
+
+            # BT old wins for bluetooth (has area_id, bt_new doesn't)
+            assert result["scanner_devreg_bt"] is bt_old, f"BT selection wrong for order {[e.id for e in order]}"
+            # ESPHome wins for mac (only mac entry)
+            assert result["scanner_devreg_mac"] is esphome_entry
+
+            # BT area_id preferred (Kitchen from bt_old)
+            assert downstream["area_id"] == "kitchen_id"
+            # MAC name preferred (esphome-kitchen from esphome_entry)
+            assert downstream["name_devreg"] == "esphome-kitchen"
+            # MAC name_by_user as fallback (bt_old has None)
+            assert downstream["name_by_user"] == "Kitchen Proxy"
+            # MAC address preferred for unique_id
+            assert downstream["unique_id"] == "aa:bb:cc:dd:ee:00"
+            # BT address preferred for BLE MAC
+            assert downstream["address_ble_mac"] == "aa:bb:cc:dd:ee:00"
+
+    def test_no_area_anywhere_clears_area(self) -> None:
+        """When neither BT nor MAC entry has area_id, area should be None."""
+        bt_entry = _make_entry_with_connections(
+            area_id=None,
+            name_by_user=None,
+            name="AA:BB:CC:DD:EE:02",
+            entry_id="bt_id",
+            connections={("bluetooth", "AA:BB:CC:DD:EE:02")},
+        )
+        mac_entry = _make_entry_with_connections(
+            area_id=None,
+            name_by_user=None,
+            name="esphome-unnamed",
+            entry_id="mac_id",
+            connections={("mac", "AA:BB:CC:DD:EE:00")},
+        )
+
+        result = _run_classification_loop([bt_entry, mac_entry])
+        downstream = _run_downstream_selection(result)
+
+        assert downstream["area_id"] is None


### PR DESCRIPTION
[Fix scanner naming/area loss by preferring DeviceEntries with richer …](https://github.com/jleinenbach/bermuda/commit/f6559bf5e00f1f334297773afaa8c1d47f18637c) 

…metadata

When multiple DeviceEntries match a single BLE scanner (e.g., ESPHome's "mac"
entry + HA Bluetooth's auto-created "bluetooth" entry + a second BT entry with
BLE MAC), the classification loop unconditionally overwrote scanner_devreg_bt
and scanner_devreg_mac with the last-processed entry. Since HA 2025.2.0 auto-
creates Bluetooth DeviceEntries with MAC-as-name and no area assignment, these
entries could overwrite user-configured ESPHome/Shelly entries that had area_id
and name_by_user set, causing scanners to lose their room/floor assignments.

The fix adds _is_better_entry() which prefers entries with area_id first, then
name_by_user as tiebreaker, ensuring user-configured entries always win over
auto-created ones regardless of iteration order.

https://claude.ai/code/session_01RJvSsgXaHvHj9SnfdimbHf
@[claude](https://github.com/jleinenbach/bermuda/commits?author=claude)
claude committed 34 minutes ago
[Fix MAC address normalization and add regression tests for scanner en…](https://github.com/jleinenbach/bermuda/commit/0254fe63835a7bec915eb0847256336dac6a9a9c) 

…try selection

- Add .lower() to scanner_devreg_mac_address (pre-existing bug: MAC from
  "mac" connection type was not lowercased, unlike "bluetooth" which was)
- Add tests for DeviceEntry with both bluetooth and mac connections
- Add regression tests for downstream area_id/name/address priority logic
- Test all 6 iteration orders for 3-entry scenario to verify determinism

https://claude.ai/code/session_01RJvSsgXaHvHj9SnfdimbHf
@[claude](https://github.com/jleinenbach/bermuda/commits?author=claude)
claude committed 1 minute ago