### PR TITLE
Add user documentation for fingerprint training and scanner calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,49 +56,53 @@ Track devices on the Google Find My Device Network -- Android phones, Pixel Buds
 - **Device congealment**: Bermuda sensors automatically appear inside the same Home Assistant device card as the GoogleFindMy-HA entities, giving you a single unified view per tracker.
 - Supports shared trackers across multiple Google accounts -- each account gets its own independent Bermuda entities without collisions.
 
-### Fingerprint-Based Room Detection (UKF)
+### Fingerprint-Based Room Detection
 
-An optional Unscented Kalman Filter (UKF) mode that fuses RSSI data from multiple scanners and matches the result against learned room fingerprints using Mahalanobis distance.
+An optional advanced detection mode that combines signal data from multiple scanners and matches the result against learned room fingerprints to determine which room a device is in.
 
 - Opt-in via the `Use UKF area selection` toggle in Global Options.
-- Falls back to the standard min-distance algorithm when UKF confidence is low (below the switching threshold of 0.3).
-- Enables detection of **scannerless rooms** -- rooms that have no BLE scanner of their own (see below).
+- Falls back to the standard distance-based algorithm when fingerprint confidence is low.
+- Enables detection of **scannerless rooms** -- rooms that have no Bluetooth scanner of their own (see below).
 
 ### Manual Fingerprint Training
 
 Per-device UI to teach the system what a room "looks like" from the perspective of all visible scanners.
 
 - **Floor** and **Room** dropdown selectors per device.
-- **Learn** button starts a training session: collects 60 unique RSSI samples over up to 5 minutes with a minimum 5-second interval between samples to ensure statistical independence.
-- Uses a **dual-filter architecture**: a button-trained anchor filter and a continuous auto-learning filter, combined via Clamped Bayesian Fusion. The user's training always retains at least 70% authority; auto-learning can refine but never overpower it.
+- **Learn** button starts a training session: collects 60 unique signal samples over up to 5 minutes with a minimum 5-second interval between samples to ensure data quality.
+- Your manual training always takes priority (at least 70% influence). The system can refine the fingerprint slightly over time to adapt to environmental changes, but it can never overpower what you trained.
 - **Reset Training** button to clear all user training for a device and fall back to auto-learned data.
 - **Multi-position training**: training the same room again from a different position averages both positions into the fingerprint rather than overwriting it.
 
+**[Read the full Fingerprint Training Guide](docs/fingerprint-training.md)** for step-by-step instructions, when to reset training data, and scannerless room setup.
+
 ### Scannerless Room Detection
 
-Rooms without their own BLE scanner (basements, storage rooms, hallways) can be detected through fingerprint matching after manual training.
+Rooms without their own Bluetooth scanner (basements, storage rooms, hallways) can be detected through fingerprint matching after manual training.
 
-- A trained scannerless room receives a **virtual distance** derived from the UKF fingerprint match score, allowing it to compete against physical scanner distances in the min-distance algorithm.
-- Topological sanity checks prevent a scannerless room from winning if no scanner on its floor sees the device at all.
+- After training, the scannerless room receives a calculated distance based on how well the current signal pattern matches the trained fingerprint, allowing it to compete against rooms with physical scanners.
+- Safety checks prevent a scannerless room from being selected if no scanner on its floor sees the device at all.
 - Requires explicit user training -- auto-learning alone cannot create scannerless room profiles.
 
 ### Enhanced Area Stability
 
-Multiple layers of protection against room flickering caused by BLE signal noise:
+Multiple layers of protection against room flickering caused by Bluetooth signal noise:
 
-- **Variance-based stability margins**: uses Gaussian Error Propagation to convert Kalman filter RSSI variance into distance variance. A challenger must improve by a statistically significant amount (2-3 sigma depending on movement state) to trigger a room switch.
-- **Movement state awareness**: devices transition through MOVING (0-2 min), SETTLING (2-10 min), and STATIONARY (10+ min) states. Stationary devices require stronger evidence (3 sigma / 99.7% confidence) to switch rooms.
+- **Noise-aware stability margins**: the system accounts for measurement uncertainty when deciding whether to switch rooms. A challenger room must be closer by a statistically significant amount -- not just a little closer due to random signal fluctuation.
+- **Movement state awareness**: devices transition through MOVING (0-2 min), SETTLING (2-10 min), and STATIONARY (10+ min) states. Stationary devices require stronger evidence to switch rooms, reducing false room changes.
 - **Cross-floor streak protection**: switching floors requires 6 consecutive wins (vs 4 for same-floor switches) and additional history checks.
-- **Soft incumbent protection**: when a scanner temporarily stops sending data, challengers still need sustained evidence before replacing the incumbent area.
+- **Soft incumbent protection**: when a scanner temporarily stops sending data, challengers still need sustained evidence before replacing the current room.
 
 ### Scanner Auto-Calibration
 
-Automatic RSSI offset calibration using mutual cross-visibility between scanners (scanners that can see each other's iBeacon advertisements).
+Automatic offset calibration using mutual visibility between scanners (scanners that can see each other's Bluetooth signals).
 
-- Calculates suggested per-scanner RSSI offsets to normalize hardware differences.
-- Compensates for different TX power levels across scanner hardware.
-- Multi-factor confidence scoring (sample count, pair count, consistency) -- only shows suggestions above 70% confidence.
-- Not persisted across restarts; recalibrates automatically after each reboot.
+- Calculates suggested per-scanner offsets to normalize hardware differences between ESP32 boards and Shelly devices.
+- Compensates for different transmit power levels across scanner hardware.
+- Multi-factor confidence scoring -- only shows suggestions above 70% confidence.
+- Not persisted across restarts; recalibrates automatically after each reboot (typically converges within 2-4 hours).
+
+**[Read the full Scanner Calibration Guide](docs/scanner-calibration.md)** for step-by-step instructions, including how to use the auto-calibration suggestions.
 
 ### Recorder Database Optimization
 
@@ -125,6 +129,14 @@ Reduces Home Assistant database writes by approximately 98%, which is critical f
   [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jleinenbach&repository=bermuda&category=Integration)
 
 ## Documentation and help
+
+### Guides
+
+- **[Fingerprint Training Guide](docs/fingerprint-training.md)** -- How to teach Bermuda what your rooms look like. Covers regular rooms, scannerless rooms, multi-position training, and when to reset training data.
+- **[Scanner Calibration Guide](docs/scanner-calibration.md)** -- How to calibrate distance accuracy. Covers the global distance model, per-scanner RSSI offsets, and the automatic calibration suggestions.
+- **[Troubleshooting](docs/troubleshooting.md)** -- Common issues with scanners, distances, room detection, and metadevices.
+
+### Community
 
 [The Wiki](https://github.com/jleinenbach/bermuda/wiki/) is the primary and official source of information for setting up Bermuda.
 

--- a/docs/fingerprint-training.md
+++ b/docs/fingerprint-training.md
@@ -1,0 +1,355 @@
+# Fingerprint Training Guide
+
+Bermuda can determine which room a device is in by comparing the pattern of signal strengths that your Bluetooth scanners report. This pattern is called a **fingerprint**. The fingerprint training feature lets you teach Bermuda what a specific room "looks like" from the perspective of all nearby scanners.
+
+> **Key terms used in this guide:**
+> - **Scanner** -- An ESP32, Shelly, or similar device that listens for Bluetooth signals and reports them to Home Assistant.
+> - **Signal strength** -- How strong a Bluetooth signal is when it reaches a scanner. Measured in dBm (decibels relative to one milliwatt). The values are always negative: **-50 dBm is a strong signal** (device is close), **-90 dBm is a weak signal** (device is far away).
+> - **Area** -- What Home Assistant calls a "room." Each scanner and each tracked device is assigned to an area.
+> - **Floor** -- A group of areas in Home Assistant. Used to organize rooms by level (Ground Floor, First Floor, Basement, etc.).
+
+> **When do you need this?** Fingerprint training is most useful when:
+> - A device keeps flickering between two adjacent rooms.
+> - You want to track a device in a room that has **no scanner of its own** (a "scannerless room" -- for example, a basement, hallway, or storage closet).
+> - The standard distance-based detection picks the wrong room because of walls, reflections, or scanner placement.
+>
+> If your devices are already tracking correctly, you do not need to train fingerprints.
+
+---
+
+## Table of Contents
+
+- [Concepts](#concepts)
+  - [How fingerprints work](#how-fingerprints-work)
+  - [Two types of learned data](#two-types-of-learned-data)
+  - [What training does for other devices](#what-training-does-for-other-devices)
+  - [Scannerless rooms](#scannerless-rooms)
+- [Prerequisites](#prerequisites)
+- [Step-by-step: Training a room](#step-by-step-training-a-room)
+- [Step-by-step: Training a scannerless room](#step-by-step-training-a-scannerless-room)
+- [Step-by-step: Training from multiple positions](#step-by-step-training-from-multiple-positions)
+- [When to reset training data](#when-to-reset-training-data)
+- [Step-by-step: Resetting training data](#step-by-step-resetting-training-data)
+- [Frequently asked questions](#frequently-asked-questions)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Concepts
+
+### How fingerprints work
+
+Every Bluetooth scanner in your home sees your device at a different signal strength. A device standing in the kitchen might be seen as a strong signal by the kitchen scanner, a medium signal by the living room scanner, and a weak signal by the bedroom scanner. This unique combination is the "fingerprint" for the kitchen.
+
+When you train a room, Bermuda records this pattern. Later, when the device reports similar signal strengths, Bermuda recognizes the pattern and assigns the device to that room -- even if the raw distances are ambiguous.
+
+```
+                    Kitchen scanner:     strong signal  (-55 dBm)
+Device in           Living room scanner: medium signal  (-72 dBm)
+the kitchen  --->   Bedroom scanner:     weak signal    (-85 dBm)
+                    = "Kitchen fingerprint"
+```
+
+Think of it like a unique "signal signature" for each room. The kitchen has a signature, the bedroom has a different one, and Bermuda learns to tell them apart.
+
+### Two types of learned data
+
+Bermuda maintains two layers of fingerprint data:
+
+**1. Auto-learned data (shared across all devices)**
+- Created **automatically** while Bermuda is running. No action needed from you.
+- Stores a general fingerprint for each room, shared by all devices.
+- Updated continuously in the background.
+- Provides a baseline so that even devices you have never trained benefit from the general knowledge of your home's layout.
+
+**2. Button-trained data (specific to one device)**
+- Created **manually** when you press the "Learn Fingerprint" button.
+- Stores a fingerprint specific to one device in one room.
+- **Your training always takes priority.** Over time, the system may adjust the fingerprint slightly to adapt to small environmental changes (moved furniture, seasonal changes), but it can never change more than 30% from what you trained. You stay in control.
+
+### What training does for other devices
+
+Imagine you train your iPhone for the kitchen. Two things happen:
+
+1. **Your iPhone** gets a strong, personal fingerprint for the kitchen. This directly and significantly improves kitchen detection for your iPhone.
+2. **The shared "Kitchen" profile** is also updated. This is the general fingerprint used by all devices. So your partner's phone, your smartwatch, or a Bluetooth tag -- any device that has never been specifically trained -- will also benefit because Bermuda now has a better understanding of what the kitchen "looks like."
+
+Training one device improves detection for all devices to some degree, but the biggest improvement is always for the device you trained.
+
+### Scannerless rooms
+
+A scannerless room is a room that has no Bluetooth scanner of its own. Examples: a basement, a storage closet, a hallway, or any room where you have not (or cannot) place an ESP32 or Shelly device.
+
+Without fingerprint training, Bermuda cannot detect a device in a scannerless room. The distance-based algorithm only knows about rooms that have a physical scanner. **Training is the only way to make a scannerless room detectable.**
+
+After training, Bermuda calculates a "virtual distance" for the scannerless room based on how well the current signal pattern matches the trained fingerprint. A strong match means a short virtual distance, allowing the scannerless room to compete against -- and potentially beat -- rooms with actual scanners that are farther away.
+
+**Important:** Scannerless room detection requires an advanced room detection mode to be enabled. Go to **Settings > Integrations > Bermuda > Configure > Global Options** and enable **"Use UKF area selection"**. This mode compares signal patterns against learned fingerprints, which is necessary because there is no physical scanner to measure distance. It uses slightly more CPU but falls back to standard distance-based detection when it cannot make a confident decision.
+
+---
+
+## Prerequisites
+
+Before you start training, make sure:
+
+1. **All your scanners are assigned to rooms.** Go to **Settings > Devices & Services**, find each ESP32/Shelly scanner device, click on it, and verify that it has a Home Assistant **Area** (room) assigned. Bermuda cannot use a scanner that has no area.
+
+2. **Your rooms are assigned to floors.** Go to **Settings > Areas, Labels & Zones**. Make sure every area (room) has a **Floor** assigned. The training dropdowns use the floor to filter the list of available rooms.
+
+3. **The device you want to train is selected in Bermuda.** Go to **Settings > Integrations > Bermuda > Configure > Select Devices** and make sure the device is in the list of tracked devices.
+
+4. **The device is currently in range.** At least one scanner must be able to see the device. If no scanner can see the device, training will fail because there is no signal data to collect.
+
+5. **(For scannerless rooms only) Advanced mode is enabled.** Go to **Settings > Integrations > Bermuda > Configure > Global Options** and enable **"Use UKF area selection"**.
+
+---
+
+## Step-by-step: Training a room
+
+This example trains a phone for the kitchen.
+
+### 1. Go to the device page
+
+1. Open **Settings > Devices & Services**.
+2. Find the **Bermuda BLE Trilateration** integration card.
+3. Click on the device count (e.g., "5 devices") to see the list of tracked devices.
+4. Click on the device you want to train.
+
+You will see the device's entities, including:
+
+- **Training Floor** (a dropdown selector)
+- **Training Room** (a dropdown selector)
+- **Learn Fingerprint** (a button -- initially grayed out)
+- **Reset Training** (a button)
+
+### 2. Select the floor
+
+Click the **Training Floor** dropdown and select the floor where the room is located (e.g., "Ground Floor").
+
+After selecting a floor, the **Training Room** dropdown will update to show only rooms on that floor.
+
+### 3. Select the room
+
+Click the **Training Room** dropdown and select the target room (e.g., "Kitchen").
+
+After selecting the room:
+- The **Learn Fingerprint** button becomes active (no longer grayed out).
+- The device's detected area is temporarily locked to the selected room. This prevents automatic detection from moving the device to a different room while you are training.
+
+### 4. Go to the room and press "Learn Fingerprint"
+
+**Physically go to the room** with the device, then press the **Learn Fingerprint** button.
+
+- The button icon changes from a brain icon to a timer/hourglass icon.
+- A notification appears: *"Training started. Collecting 60 samples..."*
+- Bermuda now collects signal strength samples from all visible scanners for up to 5 minutes.
+- Each sample must come from a genuinely new Bluetooth advertisement (no duplicates).
+- There is a minimum 5-second gap between samples to ensure good data quality.
+
+**While training is running:**
+- **Stay in the room.** Do not leave.
+- You can move around a little within the room -- this is actually helpful because it captures the signal variation at different positions.
+- The button is disabled to prevent accidental double-clicks.
+
+### 5. Wait for completion
+
+Training finishes when one of these happens:
+- **60 samples collected** (best case, typically takes 3-5 minutes).
+- **5-minute timeout** reached (any data collected so far is still saved).
+
+A notification appears with the result:
+- **Success:** *"Collected 60/60 samples (100% quality). Device placed in Kitchen."*
+- **Partial success:** *"Collected 35/60 samples (96% quality). Device placed in Kitchen."* -- still usable, but consider retraining if quality is below 70%.
+- **Failure:** *"No scanner data available."* -- the device is out of range or offline.
+
+> **What does "quality" mean?** The quality percentage tells you how statistically reliable the collected samples are. It accounts for the fact that samples taken close together in time are partially redundant. Above 80% is good. Below 50%, consider retraining when more scanners are online or the device has a stronger signal.
+
+> **What if training is interrupted?** If Home Assistant restarts or the network drops during training, any data collected before the interruption is still saved. You can run training again to collect more samples and improve the fingerprint.
+
+### 6. Verify
+
+After training completes:
+- The **Training Floor** and **Training Room** dropdowns automatically reset to empty (no selection).
+- The **Learn Fingerprint** button goes back to its grayed-out state. This is normal.
+- The area lock is released, and normal detection resumes.
+
+The device should now show the trained room as its current area. Walk to a different room and verify that the device eventually switches. Then walk back and verify it returns to the trained room.
+
+---
+
+## Step-by-step: Training a scannerless room
+
+This example trains a device for a basement storage room that has no scanner.
+
+### 1. Enable the advanced detection mode
+
+Go to **Settings > Integrations > Bermuda > Configure > Global Options** and enable **"Use UKF area selection"**. Press Submit. This mode is required because scannerless rooms can only be detected through fingerprint pattern matching, not physical distance to a scanner.
+
+### 2. Create the room in Home Assistant (if it does not exist)
+
+Go to **Settings > Areas, Labels & Zones**. If the scannerless room does not exist yet, create it and assign it to the correct floor.
+
+### 3. Train the device
+
+Follow the same steps as [Training a room](#step-by-step-training-a-room) above. Select the scannerless room as the target. Bermuda handles the rest automatically -- it knows the room has no scanner and uses fingerprint matching instead.
+
+**Important notes for scannerless rooms:**
+- The device must still be visible to **at least one scanner somewhere** in your home. For example, a scanner on the floor above might still pick up the device's signal faintly through the ceiling. If no scanner anywhere can see the device, training cannot work.
+- After training, the "Distance" sensor will show a calculated distance based on the fingerprint match quality, not a real measured distance. This is expected.
+- **Floor requirement:** At least one scanner on the same floor as the scannerless room must be able to see the device. If no scanner on that floor picks up any signal from the device, Bermuda will not place the device in the scannerless room. This prevents impossible assignments (e.g., placing a device in a basement room when all evidence says it is on the second floor).
+
+### 4. Verify
+
+Walk to a room with a scanner. The device should switch away from the scannerless room. Walk back to the scannerless room -- the device should switch back.
+
+If the scannerless room is not detected, check:
+- Is the advanced detection mode enabled? (**Global Options > "Use UKF area selection"**)
+- Is the room assigned to a floor?
+- Is at least one scanner on the same floor able to see the device (even faintly)?
+- Did training collect enough samples (ideally 60, but at least 15 may work for basic detection)?
+- Try pressing "Reset Training" and then retraining from scratch.
+
+---
+
+## Step-by-step: Training from multiple positions
+
+Large rooms (living rooms, open-plan kitchens) have significant signal variation depending on where the device is. Training from a single position only captures one "corner" of the room. Multi-position training averages multiple positions into one broader fingerprint.
+
+### 1. Train the first position
+
+Follow the normal [training steps](#step-by-step-training-a-room). Stand in one area of the room (e.g., near the sofa).
+
+### 2. Move to a different position
+
+After the first training completes, physically move to a different part of the room (e.g., near the dining table).
+
+### 3. Train again for the same room
+
+Select the same floor and same room again, and press "Learn Fingerprint" again.
+
+Bermuda automatically detects that training data already exists for this room. Instead of overwriting the previous training, it **averages both positions** into the fingerprint. The new training session has strong initial influence (~50%) to ensure it meaningfully shifts the fingerprint toward the new position.
+
+### 4. Repeat for additional positions (optional)
+
+For very large rooms, you can train from 3-4 different positions. Each training session further broadens the fingerprint to cover more of the room.
+
+---
+
+## When to reset training data
+
+Reset training data when any of these situations apply:
+
+| Situation | Why reset helps |
+|-----------|-----------------|
+| **You trained the wrong room by accident.** | The incorrect fingerprint will make the device stick to the wrong room. Resetting removes it. |
+| **You moved a scanner to a different location.** | The old fingerprint was learned with the scanner in its previous position. It no longer matches reality. |
+| **A device is stuck in a room and will not leave.** | Incorrect or outdated training data can lock a device into a room. Resetting falls back to auto-learned data or distance-based detection. |
+| **You added or removed a scanner.** | The fingerprint was learned with a different set of scanners. The pattern may no longer be valid. |
+| **Detection got worse after training.** | If you trained under bad conditions (device was moving, a scanner was rebooting, unusual interference), the fingerprint may be noisy. |
+
+### What reset affects
+
+When you press **"Reset Training"**, the following data is cleared **for this device only**:
+
+| Data cleared | Effect |
+|--------------|--------|
+| **Your manual training** (all rooms) | The fingerprints you created by pressing "Learn Fingerprint" are removed. |
+| **Auto-learned data** (all rooms) | The automatically collected patterns for this device are also removed, because they may have been influenced by incorrect training. (The auto-learner learns based on which room the device was assigned to -- if the assignment was wrong due to bad training, the auto-learned data may also be wrong.) |
+
+**What is NOT affected:**
+- Training data for other devices is untouched.
+- Shared room profiles (the general fingerprints used by all devices) are untouched.
+- Scanner calibration settings are untouched.
+- Global configuration is untouched.
+
+After resetting, the device falls back to:
+1. Shared room profiles (if they exist from other devices' training or auto-learning).
+2. Pure distance-based detection.
+
+---
+
+## Step-by-step: Resetting training data
+
+### 1. Go to the device page
+
+1. Open **Settings > Devices & Services**.
+2. Find the **Bermuda BLE Trilateration** integration card.
+3. Click on the device count, then click the device you want to reset.
+
+### 2. Press "Reset Training"
+
+Click the **Reset Training** button. A confirmation notification appears: *"Training data cleared for [device name]."*
+
+### 3. Verify
+
+The device should now use distance-based detection or shared room profiles. If the device was stuck in a wrong room, it should start tracking correctly again.
+
+If the device still behaves incorrectly after resetting, the issue is likely not related to training data. Check the [Bermuda Troubleshooting Guide](troubleshooting.md) for other possible causes.
+
+---
+
+## Frequently asked questions
+
+### Do I need to train every device?
+
+No. Training is optional. Many devices work well with just the distance-based algorithm. Train only when you notice a problem (flickering, wrong room) or when you need scannerless room detection.
+
+### Do I need to train every room?
+
+No. Train only the rooms where detection is problematic. Rooms with a scanner close to where the device usually sits typically work fine without training.
+
+### Can I train a device that uses a rotating MAC address (iPhone, Android)?
+
+Yes. Bermuda automatically identifies your device even when its Bluetooth address changes (which iPhones and Android phones do for privacy). The training is stored against the device's stable identity, not its temporary address. No special steps are needed.
+
+### How long does training last?
+
+Indefinitely. The trained fingerprint does not expire. The system may adjust it slightly over time (up to 30% influence from auto-learning), but your training remains dominant. If you move furniture or scanners, consider retraining.
+
+### What happens if a scanner goes offline during training?
+
+Training will still collect samples from the remaining online scanners. The quality may be lower because fewer scanners contribute data. If possible, make sure all scanners are online before training.
+
+### Can two people train the same device at the same time?
+
+No. The "Learn Fingerprint" button is disabled while training is in progress. Wait for the current session to finish.
+
+### Does scanner calibration affect fingerprints?
+
+No. Fingerprints are based on raw signal strength values, not calibrated distances. You can change calibration settings at any time without invalidating your fingerprint training. See the [Scanner Calibration Guide](scanner-calibration.md) for details on calibration.
+
+---
+
+## Troubleshooting
+
+### Training button is grayed out
+
+- You must select **both** a floor **and** a room before the button becomes active.
+- If a training session is already running, the button is disabled until it finishes.
+
+### Training completed but quality is low (below 50%)
+
+- The device may be at the edge of scanner range. Move closer to the center of the room.
+- A scanner may have been offline during training. Check the "Scanner Online" sensor for each scanner.
+- The Bluetooth advertisement interval of the device may be very long. Some battery-powered devices only advertise every 10+ seconds, which means fewer samples per minute.
+
+### Device still shows the wrong room after training
+
+- If you trained a scannerless room, verify the advanced detection mode is enabled (**Global Options > "Use UKF area selection"**).
+- Check that the device is still in range of at least one scanner.
+- Walk out of and back into the trained room. The system needs to see a room transition to apply the new fingerprint.
+- If the device was previously trained for a different room, that old training may conflict. Press "Reset Training" first, then retrain.
+
+### "No scanner data available" error during training
+
+- The device is not currently visible to any scanner.
+- Make sure the device is powered on and its Bluetooth is active.
+- Check that at least one scanner is online (look for the "Scanner Online" binary sensor on each scanner's device page).
+
+### Scannerless room is not detected
+
+- Is the advanced detection mode enabled? (**Global Options > "Use UKF area selection"**)
+- Is the room assigned to a floor in Home Assistant?
+- Is at least one scanner on the same floor as the scannerless room picking up the device's signal?
+- Did training collect enough samples? Ideally 60, but at least 15 may work for basic detection.
+- Try pressing "Reset Training" and retraining from scratch.

--- a/docs/scanner-calibration.md
+++ b/docs/scanner-calibration.md
@@ -1,0 +1,349 @@
+# Scanner Calibration Guide
+
+Bermuda estimates how far away a Bluetooth device is by measuring the strength of its radio signal. This conversion from signal strength to distance depends on calibration parameters. Proper calibration gives you more accurate distances and better room detection.
+
+> **Key terms used in this guide:**
+> - **Scanner** -- An ESP32, Shelly, or similar device that listens for Bluetooth signals and reports them to Home Assistant.
+> - **Signal strength (dBm)** -- How strong a Bluetooth signal is when it reaches a scanner. Measured in dBm (decibels relative to one milliwatt). Always negative: **-50 dBm is strong** (close), **-90 dBm is weak** (far away).
+> - **dB (decibel)** -- A unit of relative measurement. When used for offsets or corrections in this guide, it means "shift the reading by this many decibels." A +3 dB offset makes a scanner read stronger (closer); a -3 dB offset makes it read weaker (farther).
+> - **Reference Power (ref_power)** -- The expected signal strength at exactly 1 meter distance. This is the baseline for all distance calculations.
+> - **Attenuation** -- How quickly the signal weakens with distance. Higher values mean the signal fades faster (walls, furniture, people absorb signal).
+
+There are two calibration steps, and they build on each other:
+
+| Step | What it does | When to do it |
+|------|-------------|---------------|
+| **Calibration 1: Global** | Sets the baseline distance model (reference power and signal decay) for your entire home. | Once, when you first set up Bermuda. Repeat if you change scanner hardware. |
+| **Calibration 2: Per-Scanner Offsets** | Compensates for hardware differences between individual scanners (some ESP32 boards receive signals louder or quieter than others). | After Calibration 1. Bermuda also provides automatic suggestions. |
+
+> **Do you need to calibrate?** If your room detection is already working well with the defaults, you can skip calibration. It primarily improves the accuracy of the distance values. If you use fingerprint training for room detection, calibration is not required at all -- fingerprints use raw signal values and are unaffected by calibration settings. See the [Fingerprint Training Guide](fingerprint-training.md) for details.
+
+---
+
+## Table of Contents
+
+- [How it works (plain language)](#how-it-works-plain-language)
+- [What the parameters mean](#what-the-parameters-mean)
+- [Automatic calibration suggestions](#automatic-calibration-suggestions)
+- [Prerequisites](#prerequisites)
+- [Step-by-step: Global calibration (Calibration 1)](#step-by-step-global-calibration-calibration-1)
+- [Step-by-step: Per-scanner offsets (Calibration 2)](#step-by-step-per-scanner-offsets-calibration-2)
+- [Worked example: Calibration 2 with numbers](#worked-example-calibration-2-with-numbers)
+- [Understanding the auto-calibration suggestions](#understanding-the-auto-calibration-suggestions)
+- [Frequently asked questions](#frequently-asked-questions)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## How it works (plain language)
+
+Bermuda converts the signal strength a scanner measures into a distance estimate. Two parameters control this conversion:
+
+1. **Reference Power** answers: *"How strong is the signal at exactly 1 meter?"* This is the starting point. If you hold a device 1 meter from a scanner, the signal strength you see should match this value. The default is **-55 dBm**.
+
+2. **Attenuation** answers: *"How fast does the signal fade as you move farther away?"* In an open room, signals fade slowly (low attenuation). In a cluttered room with thick walls and lots of furniture, signals fade quickly (high attenuation). The default is **3.0**.
+
+Together, these two values let Bermuda translate any signal reading into an approximate distance. If the distances Bermuda reports do not match reality, adjusting these parameters will bring them in line.
+
+<details>
+<summary><strong>Technical detail: the distance formula</strong></summary>
+
+Bermuda uses the log-distance path loss model:
+
+```
+distance = 10 ^ ((ref_power - signal_strength) / (10 * attenuation))
+```
+
+Where:
+- `ref_power` is the expected signal strength at 1 meter (e.g., -55 dBm)
+- `signal_strength` is the actual signal measured by the scanner right now
+- `attenuation` is the path loss exponent (typically 2.0 to 4.0 indoors)
+
+You do not need to understand this formula to calibrate Bermuda. The step-by-step instructions below guide you through the process using trial and error.
+
+</details>
+
+---
+
+## What the parameters mean
+
+| Parameter | What it controls | How to think about it | Default |
+|-----------|------------------|----------------------|---------|
+| **Reference Power** | The expected signal strength at exactly 1 meter. | "If I hold the device 1 m from the scanner, what signal do I see?" A higher (less negative) value means the device appears closer. | -55.0 dBm |
+| **Attenuation** | How fast the signal decays with distance. Higher = faster decay = shorter calculated distances. | Thick walls, lots of furniture, and water (humans!) increase attenuation. Open spaces decrease it. | 3.0 |
+| **Per-scanner offset** | A correction (in dB) applied to one specific scanner to compensate for hardware differences. | "This scanner consistently reads 5 dB louder than all others, so subtract 5." Positive offset = scanner reads closer. Negative offset = scanner reads farther. | 0 |
+
+---
+
+## Automatic calibration suggestions
+
+Bermuda can automatically calculate suggested offsets for your scanners. This works because your scanners can "see" each other.
+
+**How it works (simplified):**
+
+Each ESPHome Bluetooth proxy scanner broadcasts its own Bluetooth signal (called an iBeacon advertisement). Other scanners pick up this signal, just like they pick up signals from your phone or a beacon tag. This means Scanner A sees Scanner B's signal, and Scanner B sees Scanner A's signal.
+
+If Scanner A consistently reports Scanner B's signal as much stronger than Scanner B reports Scanner A's signal, then one of them has a more sensitive receiver than the other. Bermuda uses this difference to calculate correction offsets.
+
+**In practice:**
+1. Your scanners automatically see each other in the background. You do not need to do anything.
+2. Bermuda tracks these measurements and calculates what offset each scanner needs.
+3. After enough data (typically 2-4 hours after startup), suggestions appear in the Calibration 2 dialog.
+4. Suggestions are only shown when Bermuda is at least 70% confident in the result.
+
+> **Note:** Auto-calibration data is recalculated fresh after every Home Assistant restart. Suggestions may take a few hours to appear after a reboot.
+
+---
+
+## Prerequisites
+
+Before calibrating:
+
+1. **All your scanners are online and assigned to rooms.** Calibration requires active scanners with Bluetooth data flowing.
+2. **You have a measuring tape or know the approximate distance.** For Calibration 1, you will place a device at 1 meter and then at 5+ meters from a scanner.
+3. **You have at least one device selected in Bermuda.** Go to **Settings > Integrations > Bermuda > Configure > Select Devices** and choose a device you can physically carry (a phone or a beacon tag).
+
+---
+
+## Step-by-step: Global calibration (Calibration 1)
+
+This example calibrates the global distance model using a phone and a kitchen scanner.
+
+### 1. Open the calibration dialog
+
+Go to **Settings > Integrations > Bermuda BLE Trilateration**. Click **Configure**. In the menu, select **"Calibration 1: Global"**.
+
+### 2. Select a reference pair
+
+You will see two dropdown fields:
+
+- **Reference device:** Select the Bluetooth device you will carry (e.g., your phone).
+- **Reference scanner:** Select the scanner you will calibrate against (e.g., "Kitchen ESP32").
+
+Choose a scanner in a room where you have enough space to stand 1 meter away and then move to 5+ meters away.
+
+### 3. Calibrate at 1 meter
+
+1. Hold the device at **exactly 1 meter** from the selected scanner.
+2. Click **Submit**.
+3. A results table appears showing the last 5 signal readings and their calculated distances.
+
+Look at the **Estimate (m)** row. If the values are not close to 1.0 m, adjust the **Reference Power** field:
+- If the distance reads **too far** (e.g., 2.5 m), **increase** reference power (make it less negative, e.g., -55 to -50).
+- If the distance reads **too close** (e.g., 0.3 m), **decrease** reference power (make it more negative, e.g., -55 to -60).
+
+Click **Submit** again to see the updated distances. Repeat until the 1-meter reading is approximately correct.
+
+### 4. Calibrate at 5+ meters
+
+1. Measure a distance of 5 meters (or more) from the scanner using a tape measure.
+2. Hold the device at that distance.
+3. Click **Submit** and check the results table.
+
+Now adjust the **Attenuation** field:
+- If the distance reads **too far** (e.g., 8 m when actual is 5 m), **increase** attenuation (e.g., 3.0 to 3.5).
+- If the distance reads **too close** (e.g., 3 m when actual is 5 m), **decrease** attenuation (e.g., 3.0 to 2.5).
+
+Click **Submit** again to verify. Repeat until the 5-meter reading is approximately correct.
+
+> **Tip:** After adjusting attenuation, go back and verify the 1-meter reading is still correct. The two parameters interact slightly. You may need to iterate a few times between steps 3 and 4.
+
+### 5. Save
+
+> **Important:** Your changes are NOT saved until you check the **"Save and Close"** checkbox. If you just click Submit without this checkbox, Bermuda will show you updated results but will not persist your changes.
+
+Check the **"Save and Close"** checkbox and click **Submit**. The calibration is saved.
+
+---
+
+## Step-by-step: Per-scanner offsets (Calibration 2)
+
+This step compensates for hardware differences between individual scanners. Some ESP32 boards have more sensitive receivers than others, even if they are the same model.
+
+### 1. Open the calibration dialog
+
+Go to **Settings > Integrations > Bermuda BLE Trilateration**. Click **Configure**. In the menu, select **"Calibration 2: Scanner RSSI Offsets"**.
+
+### 2. Select a device first
+
+> **The screen will look mostly empty at first. This is expected.** Bermuda needs to know which device's signal data to use before it can show any distances. Until you select a device, there is nothing to display.
+
+Click the **Device** dropdown and select a tracked Bluetooth device (e.g., your phone). Then click **Submit**.
+
+After submitting, a **results table** appears showing the estimated distance from the selected device to each scanner. The table has 5 columns (samples 0-4) showing recent distance estimates.
+
+### 3. Review the auto-calibration suggestions (if available)
+
+Below the distance table, you may see an **"Auto-Calibration Suggestions"** table. This shows:
+
+| Column | Meaning |
+|--------|---------|
+| **Scanner** | The scanner name |
+| **Current** | Your current offset for this scanner (in dB) |
+| **Suggested** | The offset Bermuda recommends based on scanner cross-visibility data |
+| **Confidence** | How confident the suggestion is (0-100%). Only values above 70% are shown. |
+
+If suggestions are available, you can apply them by typing the suggested values into the scanner offset fields.
+
+> **No suggestions yet?** Auto-calibration needs 2-4 hours of data after each Home Assistant restart. You also need at least 2 scanners that can see each other. If you just rebooted, wait a few hours and check again.
+
+### 4. Adjust offsets manually (if needed)
+
+If auto-calibration suggestions are not available, or you want to fine-tune:
+
+1. Pick one scanner as your **reference scanner** (leave its offset at 0).
+2. Place the device at a known distance from the reference scanner and note the reported distance.
+3. Move to another scanner at approximately the same known distance and compare.
+   - If this scanner reports **too close**, apply a **negative** offset (e.g., -3).
+   - If this scanner reports **too far**, apply a **positive** offset (e.g., +3).
+4. Click **Submit** to see the updated distances.
+5. Repeat for each scanner.
+
+### 5. Save
+
+> **Important:** Your changes are NOT saved until you check the **"Save and Close"** checkbox. If you just click Submit without this checkbox, Bermuda will show you updated results but will not persist your changes.
+
+Check the **"Save and Close"** checkbox and click **Submit**. The offsets are saved.
+
+---
+
+## Worked example: Calibration 2 with numbers
+
+Here is a concrete example showing how to interpret the results table and apply offsets.
+
+**Setup:** You have 3 scanners and a phone. You place the phone **3 meters** from each scanner (one at a time) and note the reported distances.
+
+| Scanner | Reported distance | Actual distance | Problem |
+|---------|-------------------|-----------------|---------|
+| Kitchen ESP32 (reference) | 3.1 m | 3 m | Close enough -- leave at 0. |
+| Bedroom ESP32 | 4.8 m | 3 m | Reports too far. Scanner reads too weak. |
+| Living Room Shelly | 2.0 m | 3 m | Reports too close. Scanner reads too strong. |
+
+**Applying offsets:**
+
+1. **Kitchen ESP32** -- offset stays at **0** (reference scanner).
+2. **Bedroom ESP32** -- reports 4.8 m instead of 3 m (too far). The scanner's receiver is less sensitive, so signals appear weaker than they actually are. Apply a **positive** offset to correct this. Try **+3** and check.
+3. **Living Room Shelly** -- reports 2.0 m instead of 3 m (too close). The scanner's receiver is more sensitive, so signals appear stronger than they actually are. Apply a **negative** offset. Try **-3** and check.
+
+After applying offsets and pressing Submit, the new table might show:
+
+| Scanner | Reported distance (after offset) | Target |
+|---------|----------------------------------|--------|
+| Kitchen ESP32 | 3.1 m | 3 m |
+| Bedroom ESP32 | 3.3 m | 3 m |
+| Living Room Shelly | 2.9 m | 3 m |
+
+These are close enough. Check **"Save and Close"** and press **Submit** to save.
+
+> **Tip:** You do not need perfect accuracy. Within 0.5 m of the actual distance is usually good enough for room detection. The goal is to eliminate large systematic errors, not achieve centimeter precision.
+
+---
+
+## Understanding the auto-calibration suggestions
+
+### How confidence is calculated
+
+The confidence score is based on three factors:
+
+| Factor | Weight | What it measures |
+|--------|--------|------------------|
+| **Sample count** | 30% | How many signal samples have been collected between this scanner pair. Reaches full score at 100 samples. |
+| **Scanner pair count** | 40% | How many other scanners can see this scanner. More pairs means better cross-validation. 1 pair = 33%, 2 pairs = 67%, 3+ pairs = 100%. |
+| **Consistency** | 30% | How consistent the calculated offset is across different scanner pairs. Lower variation = higher confidence. |
+
+Suggestions are only displayed when the combined confidence reaches **70% or higher**.
+
+### What "below threshold" means
+
+If a scanner shows confidence but says "below threshold", it means Bermuda has some data but not enough to be confident in the suggestion. This usually means:
+- Not enough time has passed since the last restart (auto-calibration data is not persisted across restarts).
+- Only one or two scanner pairs are available.
+- The signal readings between the scanners are highly variable.
+
+Give it more time. Suggestions typically become reliable after 2-4 hours of operation.
+
+### Why suggestions are not saved across restarts
+
+Auto-calibration data is recalculated fresh after every Home Assistant restart. This is by design:
+- Scanner hardware or positions may have changed.
+- Stale calibration data could be worse than no calibration.
+- The system converges within a few hours of normal operation.
+
+The offsets you manually enter and save **are** persisted. Only the auto-calculated suggestions reset.
+
+---
+
+## Frequently asked questions
+
+### Do I need both Calibration 1 and Calibration 2?
+
+Not necessarily.
+- **Calibration 1** sets the global model. It is the most impactful step.
+- **Calibration 2** fine-tunes per-scanner differences. It is most useful if you notice that one scanner consistently reports wrong distances while others are correct.
+
+If your room detection works well, you can skip both.
+
+### Does calibration affect fingerprint training?
+
+No. Fingerprints use raw signal strength values, not calibrated distances. You can change calibration settings at any time without invalidating your fingerprint training data. See the [Fingerprint Training Guide](fingerprint-training.md) for details.
+
+### Why do I need to select a device in Calibration 2 before seeing the table?
+
+The distance table requires actual signal data from a specific device to calculate distances. Without selecting a device, there is no data to display. Once you select a device and press Submit, Bermuda retrieves that device's recent signal history from each scanner and shows the calculated distances.
+
+This is a one-time step each time you open the dialog. After selecting a device, you can adjust offsets and press Submit multiple times to iterate.
+
+### How often should I recalibrate?
+
+Rarely. Recalibrate if:
+- You replace scanner hardware (different ESP32 boards have different receiver sensitivities).
+- You physically move a scanner to a new location.
+- You add or remove scanners.
+- Distance values seem consistently wrong across all devices.
+
+### Can I undo calibration changes?
+
+Yes, but there is no "Reset to defaults" button. Manually set the values back to their defaults:
+- **Reference Power:** -55.0
+- **Attenuation:** 3.0
+- **All per-scanner offsets:** 0
+
+Then check **"Save and Close"** and Submit.
+
+### Do I need to recalibrate after changing fingerprint training?
+
+No. Calibration and fingerprint training are completely independent. Fingerprints use raw signal values. Calibration affects only the calculated distances.
+
+---
+
+## Troubleshooting
+
+### No auto-calibration suggestions appear
+
+- **Scanners need to see each other.** This requires ESPHome-based scanners with Bluetooth proxy enabled, or Shelly devices that broadcast Bluetooth signals. The scanners must be close enough to detect each other's signal.
+- **Give it time.** After a restart, it takes 2-4 hours for enough data to accumulate.
+- **Check scanner count.** You need at least 2 scanners that can see each other for suggestions to appear.
+
+### Distances are wildly wrong
+
+- **Check reference power sign.** It must be negative (e.g., -55, not +55). A positive reference power causes extreme distance errors.
+- **Check attenuation range.** Typical values are 2.0 to 4.0. Values outside this range produce unrealistic distances.
+- **Check scanner health.** A rebooting or offline scanner will not provide reliable data.
+
+### One scanner always reports wrong distances
+
+This is exactly what Calibration 2 (per-scanner offsets) is for. Apply a positive or negative offset to that scanner until its distances match reality. Or wait for auto-calibration suggestions.
+
+### Distances are correct at 1 m but wrong at 5 m (or vice versa)
+
+This is an attenuation issue. Iterate between Calibration 1 steps 3 and 4, adjusting reference power and attenuation alternately until both distances are approximately correct.
+
+### The Calibration 2 screen looks empty
+
+This is expected if you have not selected a device yet. Select a device from the dropdown and press Submit. The distance table will then appear.
+
+### After pressing Submit, my changes seem to disappear
+
+If you did not check the **"Save and Close"** checkbox before pressing Submit, your changes were used to recalculate the preview but were not saved. To save permanently, check the **"Save and Close"** checkbox and press Submit again.
+
+For additional troubleshooting, see the [Bermuda Troubleshooting Guide](troubleshooting.md).


### PR DESCRIPTION
Create comprehensive user-facing guides for two key features:
- docs/fingerprint-training.md: Complete guide covering training workflow, scannerless room detection, multi-position training, when to reset, FAQ
- docs/scanner-calibration.md: Complete guide covering two-step calibration process, auto-calibration suggestions, worked examples, FAQ

Both guides include key terms boxes, plain-language explanations before technical details, concrete step-by-step workflows, and troubleshooting sections. Technical formulas are placed in collapsible sections.

Update README.md to link to the new guides and reduce jargon in feature descriptions (replace terms like "Gaussian Error Propagation", "Mahalanobis distance", "Clamped Bayesian Fusion" with plain-language equivalents).

https://claude.ai/code/session_01ChKfCydhnwQpKSSrq4Hzxo