### PR TITLE
Add scanner device congealment to merge BLE scanner+tracker duplicates

### DIFF
--- a/custom_components/bermuda/entity.py
+++ b/custom_components/bermuda/entity.py
@@ -132,6 +132,18 @@ class BermudaEntity(CoordinatorEntity):
         model = None
 
         if self._device.is_scanner:
+            # Scanner device congealment: use the scanner's native integration
+            # device entry identifiers so Bermuda entities appear in the same
+            # HA device as ESPHome/Shelly/Bluetooth entities.
+            # This follows the same pattern as FMDN device congealment.
+            if self._device.entry_id:
+                scanner_device_entry = self.dr.async_get(self._device.entry_id)
+                if scanner_device_entry and scanner_device_entry.identifiers:
+                    return DeviceInfo(
+                        identifiers=scanner_device_entry.identifiers,
+                        name=self._device.name,
+                    )
+            # Fallback: use connections for congealment if entry_id lookup fails.
             # ESPHome proxies prior to 2025.3 report their WIFI MAC for any address,
             # except for received iBeacons.
             connections = set()


### PR DESCRIPTION
When a BLE scanner is also a tracked device, Bermuda previously created a separate HA device from the native integration's device (ESPHome/Shelly), causing duplicate entries in the UI. This follows the proven FMDN device congealment pattern: look up the scanner's native integration device entry via entry_id and return its identifiers in DeviceInfo, so HA merges Bermuda entities into the existing device.

Includes 7 new tests covering congealment success, fallback paths, name preservation, and multiple identifiers handling. All 1574 tests pass.

https://claude.ai/code/session_011u5HAyD5q9ar86LvFPZejN