### PR TITLE
Fix scanner device duplication: resolve WiFi MAC before entity creation

### DIFF
--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -369,10 +369,13 @@ class BermudaDevice:
             self._is_remote_scanner = True
         else:
             self._is_remote_scanner = False
-        self._coordinator.scanner_list_add(self)
-
-        # Find the relevant device entries in HA for this scanner and apply the names, addresses etc
+        # Resolve device entries FIRST (sets address_wifi_mac, address_ble_mac etc.)
+        # This MUST happen before scanner_list_add() because that dispatches
+        # SIGNAL_SCANNERS_CHANGED which triggers entity creation. Entity device_info
+        # needs address_wifi_mac to be set for proper device congealment.
         self.async_as_scanner_resolve_device_entries()
+
+        self._coordinator.scanner_list_add(self)
 
         # Call the per-update processor as well, but only
         # if this is our first ha_scanner.


### PR DESCRIPTION
Three root causes of scanner device duplication fixed:

1. bermuda_device.py: Reorder async_as_scanner_init() so async_as_scanner_resolve_device_entries() runs BEFORE scanner_list_add(). The signal dispatch triggers entity creation, and device_info needs address_wifi_mac to be set for proper congealment.

2. entity.py: Add Priority 3 MAC-offset search in device_info. When WiFi MAC resolution fails (ESPHome not loaded, non-standard offset), search device registry for CONNECTION_NETWORK_MAC at offsets -3 to +2 from the scanner's BLE address.

3. entity.py: Fix fallback connection logic. Only add CONNECTION_NETWORK_MAC when address_wifi_mac is actually known. Previously used BLE MAC as CONNECTION_NETWORK_MAC which created separate devices instead of congealing.

https://claude.ai/code/session_011u5HAyD5q9ar86LvFPZejN