### PR TITLE
Fix scanner device duplication: resolve WiFi MAC before entity creation

### DIFF
--- a/custom_components/bermuda/binary_sensor.py
+++ b/custom_components/bermuda/binary_sensor.py
@@ -73,6 +73,7 @@ class BermudaScannerOnlineSensor(BermudaEntity, BinarySensorEntity):
     timeout window (default 30 seconds), OFF otherwise.
     """
 
+    _scanner_entity = True
     _attr_has_entity_name = True
     _attr_translation_key = "scanner_online"
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY

--- a/custom_components/bermuda/entity.py
+++ b/custom_components/bermuda/entity.py
@@ -38,6 +38,14 @@ class BermudaEntity(CoordinatorEntity):
     distances etc.
     """
 
+    # Subclasses that represent scanner-specific entities (e.g., scanner
+    # online binary sensor) should set this to True.  Only those entities
+    # will be congealed onto the scanner's native device (ESPHome/Shelly).
+    # Tracking entities (distance, area, device_tracker) for dual-role
+    # devices (both scanner AND tracked) must NOT be congealed — they
+    # belong on the Bermuda device instead.
+    _scanner_entity: bool = False
+
     def __init__(
         self,
         coordinator: BermudaDataUpdateCoordinator,
@@ -131,11 +139,12 @@ class BermudaEntity(CoordinatorEntity):
         domain_name = DOMAIN
         model = None
 
-        if self._device.is_scanner:
+        if self._device.is_scanner and self._scanner_entity:
             # Scanner device congealment: use the scanner's native integration
-            # device entry identifiers so Bermuda entities appear in the same
-            # HA device as ESPHome/Shelly/Bluetooth entities.
-            # This follows the same pattern as FMDN device congealment.
+            # device entry identifiers so Bermuda scanner-specific entities
+            # appear in the same HA device as ESPHome/Shelly/Bluetooth entities.
+            # Only _scanner_entity=True entities are congealed here; tracking
+            # entities for dual-role devices use the regular Bermuda device path.
             #
             # Priority: Prefer ESPHome/Shelly device (via WiFi MAC or MAC
             # offset) over HA Bluetooth auto-created device. The ESPHome

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -146,6 +146,7 @@ class TestBermudaEntityDeviceInfo:
         address: str = "aa:bb:cc:dd:ee:ff",
         address_type: str | None = None,
         is_scanner: bool = False,
+        scanner_entity: bool = False,
         unique_id: str = "test_unique_id",
         fmdn_device_id: str | None = None,
         fmdn_canonical_id: str | None = None,
@@ -173,6 +174,7 @@ class TestBermudaEntityDeviceInfo:
         entity = object.__new__(BermudaEntity)
         entity._device = mock_device
         entity.dr = mock_dr
+        entity._scanner_entity = scanner_entity
 
         return entity
 
@@ -250,6 +252,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="aa:bb:cc:dd:ee:ff",
             is_scanner=True,
+            scanner_entity=True,
             entry_id=None,
         )
 
@@ -271,6 +274,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="48:27:e2:e3:f2:d8",
             is_scanner=True,
+            scanner_entity=True,
             entry_id="bt_device_registry_id",
             address_wifi_mac="48:27:e2:e3:f2:da",
         )
@@ -293,6 +297,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="48:27:e2:e3:f2:da",
             is_scanner=True,
+            scanner_entity=True,
             entry_id="scanner_device_registry_id",
             address_wifi_mac=None,
         )
@@ -317,6 +322,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="48:27:e2:e3:f2:d8",
             is_scanner=True,
+            scanner_entity=True,
             entry_id="bt_device_registry_id",
             address_wifi_mac="48:27:e2:e3:f2:da",
         )
@@ -342,6 +348,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="aa:bb:cc:dd:ee:ff",
             is_scanner=True,
+            scanner_entity=True,
             entry_id="nonexistent_entry_id",
         )
 
@@ -361,6 +368,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="aa:bb:cc:dd:ee:ff",
             is_scanner=True,
+            scanner_entity=True,
             entry_id="entry_with_no_identifiers",
         )
 
@@ -382,6 +390,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="48:27:e2:e3:f2:da",
             is_scanner=True,
+            scanner_entity=True,
             address_wifi_mac="48:27:e2:e3:f2:da",
         )
         entity._device.name = "BT Scanner 5 Wohnzimmer"
@@ -401,6 +410,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="48:27:e2:e3:f2:d8",
             is_scanner=True,
+            scanner_entity=True,
             address_wifi_mac="48:27:e2:e3:f2:da",
         )
 
@@ -425,6 +435,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="48:27:e2:e3:f2:d8",
             is_scanner=True,
+            scanner_entity=True,
             address_wifi_mac="48:27:E2:E3:F2:DA",  # Uppercase
         )
 
@@ -453,6 +464,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="48:27:e2:e3:f2:d8",
             is_scanner=True,
+            scanner_entity=True,
             entry_id=None,
             address_wifi_mac=None,  # WiFi MAC not resolved
             address_ble_mac="48:27:e2:e3:f2:d8",
@@ -484,6 +496,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="some:other:addr:00:00:01",
             is_scanner=True,
+            scanner_entity=True,
             entry_id=None,
             address_wifi_mac=None,
             address_ble_mac="48:27:e2:e3:f2:d8",  # BLE MAC set separately
@@ -513,6 +526,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="48:27:e2:e3:f2:d8",
             is_scanner=True,
+            scanner_entity=True,
             entry_id=None,
             address_wifi_mac=None,
             address_ble_mac="48:27:e2:e3:f2:d8",
@@ -554,6 +568,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="48:27:e2:e3:f2:d8",
             is_scanner=True,
+            scanner_entity=True,
             entry_id="bt_entry_id",
             address_wifi_mac=None,
             address_ble_mac="48:27:e2:e3:f2:d8",
@@ -588,6 +603,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="aa:bb:cc:dd:ee:ff",
             is_scanner=True,
+            scanner_entity=True,
             entry_id=None,
             address_wifi_mac=None,
         )
@@ -611,6 +627,7 @@ class TestBermudaEntityDeviceInfo:
         entity = self._create_entity(
             address="48:27:e2:e3:f2:d8",
             is_scanner=True,
+            scanner_entity=True,
             entry_id=None,
             address_wifi_mac="48:27:e2:e3:f2:da",
         )
@@ -669,6 +686,7 @@ class TestScannerPollutionFix:
         entity = object.__new__(BermudaEntity)
         entity._device = mock_device
         entity.dr = mock_dr
+        entity._scanner_entity = True
 
         return entity
 
@@ -1123,3 +1141,227 @@ class TestEntityIntegration:
         from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
         assert issubclass(BermudaGlobalEntity, CoordinatorEntity)
+
+    def test_scanner_entity_flag_defaults_to_false(self) -> None:
+        """Test that _scanner_entity defaults to False on BermudaEntity."""
+        entity = object.__new__(BermudaEntity)
+        assert entity._scanner_entity is False
+
+
+class TestDualRoleDeviceInfo:
+    """Tests for dual-role devices (both scanner AND tracked).
+
+    Dual-role devices have is_scanner=True but their tracking entities
+    (distance, area, device_tracker) should NOT be congealed onto the
+    scanner's native device (ESPHome/Shelly). Only scanner-specific
+    entities (_scanner_entity=True) should be congealed.
+    """
+
+    def _create_entity(
+        self,
+        address: str = "48:27:e2:e3:f2:d8",
+        scanner_entity: bool = False,
+        address_wifi_mac: str | None = "48:27:e2:e3:f2:da",
+        address_ble_mac: str | None = None,
+        entry_id: str | None = "some_entry_id",
+    ) -> BermudaEntity:
+        """Create a dual-role BermudaEntity (is_scanner=True)."""
+        mock_device = MagicMock()
+        mock_device.name = "Dual Role Scanner"
+        mock_device.unique_id = "dual_role_unique_id"
+        mock_device.address = address
+        mock_device.address_type = None
+        mock_device.is_scanner = True
+        mock_device.address_wifi_mac = address_wifi_mac
+        mock_device.address_ble_mac = address_ble_mac
+        mock_device.fmdn_device_id = None
+        mock_device.fmdn_canonical_id = None
+        mock_device.entry_id = entry_id
+
+        mock_dr = MagicMock()
+        mock_dr.async_get.return_value = None
+        mock_dr.async_get_device.return_value = None
+
+        # ESPHome device exists for congealment
+        mock_esphome_entry = MagicMock()
+        mock_esphome_entry.identifiers = {("esphome", "atoms3-bt-5")}
+        mock_esphome_entry.connections = frozenset({("mac", "48:27:e2:e3:f2:da")})
+        mock_dr.async_get_device.return_value = mock_esphome_entry
+
+        entity = object.__new__(BermudaEntity)
+        entity._device = mock_device
+        entity.dr = mock_dr
+        entity._scanner_entity = scanner_entity
+
+        return entity
+
+    def test_tracking_entity_uses_bermuda_device_not_esphome(self) -> None:
+        """Test that tracking entities (scanner_entity=False) use Bermuda device, not ESPHome.
+
+        This is the core fix: for dual-role devices, tracking entities like
+        distance, area, device_tracker must NOT be congealed onto the ESPHome
+        device. They should use the regular Bermuda device path with Bermuda
+        domain identifiers.
+        """
+        entity = self._create_entity(scanner_entity=False)
+
+        device_info = entity.device_info
+
+        assert device_info is not None
+        # Must use Bermuda domain identifier, NOT ESPHome
+        assert (DOMAIN, "dual_role_unique_id") in device_info["identifiers"]
+        assert ("esphome", "atoms3-bt-5") not in device_info.get("identifiers", set())
+
+    def test_scanner_entity_congeals_to_esphome(self) -> None:
+        """Test that scanner-specific entities (scanner_entity=True) congeal to ESPHome."""
+        entity = self._create_entity(scanner_entity=True)
+
+        device_info = entity.device_info
+
+        assert device_info is not None
+        # Must use ESPHome identifiers for congealment
+        assert ("esphome", "atoms3-bt-5") in device_info["identifiers"]
+        assert (DOMAIN, "dual_role_unique_id") not in device_info.get("identifiers", set())
+
+    def test_same_device_different_entity_types_different_targets(self) -> None:
+        """Test that the same device produces different device_info based on _scanner_entity.
+
+        This verifies that for the SAME physical device (same address, same is_scanner=True),
+        scanner entities go to the ESPHome device and tracking entities stay on Bermuda device.
+        """
+        scanner_ent = self._create_entity(scanner_entity=True)
+        tracking_ent = self._create_entity(scanner_entity=False)
+
+        scanner_info = scanner_ent.device_info
+        tracking_info = tracking_ent.device_info
+
+        assert scanner_info is not None
+        assert tracking_info is not None
+
+        # Scanner entity targets ESPHome device
+        assert ("esphome", "atoms3-bt-5") in scanner_info["identifiers"]
+
+        # Tracking entity targets Bermuda device
+        assert (DOMAIN, "dual_role_unique_id") in tracking_info["identifiers"]
+
+        # They MUST point to different device entries
+        assert scanner_info["identifiers"] != tracking_info["identifiers"]
+
+    def test_tracking_entity_has_bluetooth_connection(self) -> None:
+        """Test that tracking entities for scanner devices still have BLE connection."""
+        entity = self._create_entity(scanner_entity=False)
+
+        device_info = entity.device_info
+
+        assert device_info is not None
+        bluetooth_conns = [(ct, m) for ct, m in device_info["connections"] if ct == "bluetooth"]
+        assert len(bluetooth_conns) == 1
+
+
+class TestCleanupEmptyBermudaDevices:
+    """Tests for async_cleanup_empty_bermuda_devices coordinator method."""
+
+    def _make_coordinator(self) -> MagicMock:
+        """Create a mock coordinator with device and entity registries."""
+        coordinator = MagicMock()
+        coordinator.config_entry = MagicMock()
+        coordinator.config_entry.entry_id = "test_entry_id"
+        coordinator.dr = MagicMock()
+        coordinator.er = MagicMock()
+        return coordinator
+
+    def _make_device_entry(
+        self,
+        device_id: str,
+        identifiers: set,
+        name: str = "Test Device",
+    ) -> MagicMock:
+        """Create a mock device registry entry."""
+        entry = MagicMock()
+        entry.id = device_id
+        entry.name = name
+        entry.identifiers = identifiers
+        return entry
+
+    @pytest.mark.asyncio
+    async def test_removes_empty_bermuda_device(self) -> None:
+        """Test that empty Bermuda devices are removed."""
+        from custom_components.bermuda.coordinator import BermudaDataUpdateCoordinator
+
+        coordinator = self._make_coordinator()
+        empty_device = self._make_device_entry("dev1", {(DOMAIN, "aa:bb:cc:dd:ee:ff")})
+        coordinator.dr.devices.values.return_value = [empty_device]
+
+        # Device has zero entities
+        with patch(
+            "custom_components.bermuda.coordinator.er.async_entries_for_device",
+            return_value=[],
+        ):
+            await BermudaDataUpdateCoordinator.async_cleanup_empty_bermuda_devices(coordinator)
+
+        coordinator.dr.async_remove_device.assert_called_once_with("dev1")
+
+    @pytest.mark.asyncio
+    async def test_keeps_device_with_entities(self) -> None:
+        """Test that Bermuda devices with entities are kept."""
+        from custom_components.bermuda.coordinator import BermudaDataUpdateCoordinator
+
+        coordinator = self._make_coordinator()
+        device_with_entities = self._make_device_entry("dev1", {(DOMAIN, "aa:bb:cc:dd:ee:ff")})
+        coordinator.dr.devices.values.return_value = [device_with_entities]
+
+        # Device has one entity
+        mock_entity = MagicMock()
+        with patch(
+            "custom_components.bermuda.coordinator.er.async_entries_for_device",
+            return_value=[mock_entity],
+        ):
+            await BermudaDataUpdateCoordinator.async_cleanup_empty_bermuda_devices(coordinator)
+
+        coordinator.dr.async_remove_device.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_non_bermuda_devices(self) -> None:
+        """Test that non-Bermuda devices are not touched."""
+        from custom_components.bermuda.coordinator import BermudaDataUpdateCoordinator
+
+        coordinator = self._make_coordinator()
+        esphome_device = self._make_device_entry("dev1", {("esphome", "my-esp")})
+        coordinator.dr.devices.values.return_value = [esphome_device]
+
+        with patch(
+            "custom_components.bermuda.coordinator.er.async_entries_for_device",
+            return_value=[],
+        ):
+            await BermudaDataUpdateCoordinator.async_cleanup_empty_bermuda_devices(coordinator)
+
+        coordinator.dr.async_remove_device.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_global_bermuda_device(self) -> None:
+        """Test that the BERMUDA_GLOBAL device is never removed."""
+        from custom_components.bermuda.coordinator import BermudaDataUpdateCoordinator
+
+        coordinator = self._make_coordinator()
+        global_device = self._make_device_entry("dev1", {(DOMAIN, "BERMUDA_GLOBAL")})
+        coordinator.dr.devices.values.return_value = [global_device]
+
+        with patch(
+            "custom_components.bermuda.coordinator.er.async_entries_for_device",
+            return_value=[],
+        ):
+            await BermudaDataUpdateCoordinator.async_cleanup_empty_bermuda_devices(coordinator)
+
+        coordinator.dr.async_remove_device.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_config_entry(self) -> None:
+        """Test that cleanup does nothing when config_entry is None."""
+        from custom_components.bermuda.coordinator import BermudaDataUpdateCoordinator
+
+        coordinator = self._make_coordinator()
+        coordinator.config_entry = None
+
+        await BermudaDataUpdateCoordinator.async_cleanup_empty_bermuda_devices(coordinator)
+
+        coordinator.dr.async_remove_device.assert_not_called()


### PR DESCRIPTION
Three root causes of scanner device duplication fixed:

1. bermuda_device.py: Reorder async_as_scanner_init() so async_as_scanner_resolve_device_entries() runs BEFORE scanner_list_add(). The signal dispatch triggers entity creation, and device_info needs address_wifi_mac to be set for proper congealment.

2. entity.py: Add Priority 3 MAC-offset search in device_info. When WiFi MAC resolution fails (ESPHome not loaded, non-standard offset), search device registry for CONNECTION_NETWORK_MAC at offsets -3 to +2 from the scanner's BLE address.

3. entity.py: Fix fallback connection logic. Only add CONNECTION_NETWORK_MAC when address_wifi_mac is actually known. Previously used BLE MAC as CONNECTION_NETWORK_MAC which created separate devices instead of congealing.

https://claude.ai/code/session_011u5HAyD5q9ar86LvFPZejN