### PR TITLE
Exclude volatile attributes from recorder to reduce DB bloat

### DIFF
--- a/custom_components/bermuda/binary_sensor.py
+++ b/custom_components/bermuda/binary_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.const import EntityCategory
+from homeassistant.const import MATCH_ALL, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -78,6 +78,13 @@ class BermudaScannerOnlineSensor(BermudaEntity, BinarySensorEntity):
     _attr_translation_key = "scanner_online"
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    # Exclude ALL extra_state_attributes from the recorder database.
+    # last_seen_age_seconds is recalculated every coordinator cycle (~1.05s),
+    # creating a new DB row per cycle per scanner entity. This is pure
+    # real-time diagnostic info with no historical value.
+    # The binary state itself (ON/OFF) is still recorded normally.
+    _unrecorded_attributes = frozenset({MATCH_ALL})
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/bermuda/device_tracker.py
+++ b/custom_components/bermuda/device_tracker.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.device_tracker.config_entry import BaseTrackerEntity
 from homeassistant.components.device_tracker.const import SourceType
-from homeassistant.const import STATE_HOME
+from homeassistant.const import MATCH_ALL, STATE_HOME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -81,6 +81,13 @@ class BermudaDeviceTracker(BermudaEntity, BaseTrackerEntity):
     # BaseTrackerEntity narrows Entity's EntityCategory | None to EntityCategory,
     # but we intentionally want None here (no category = primary entity).
     _attr_entity_category = None  # type: ignore[assignment]
+
+    # Exclude ALL extra_state_attributes from the recorder database.
+    # The "scanner" and "area" attributes duplicate data already available
+    # from dedicated sensor entities (BermudaSensor, BermudaSensorScanner).
+    # Recording them here creates redundant DB writes on every area change.
+    # The device_tracker state itself (home/not_home/zone) is still recorded.
+    _unrecorded_attributes = frozenset({MATCH_ALL})
 
     @property
     def unique_id(self) -> str:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1383,18 +1383,19 @@ class TestRecorderBaseline:
         assert "last_good_distance_age_s" in unrecorded
         assert "area_retention_seconds_remaining" in unrecorded
 
-    def test_area_sensor_stable_attributes_not_excluded(self) -> None:
-        """STAGE 1: Stable attributes are NOT excluded from recorder.
+    def test_area_sensor_metadata_attributes_excluded(self) -> None:
+        """All area_state_metadata() attributes are excluded from recorder.
 
-        area_is_stale, area_retained, area_source change rarely and are
-        valuable for history analysis.
+        area_is_stale, area_retained, area_source change on state transitions
+        and force new attribute DB rows even though the primary state hasn't
+        changed. They are available in live state but excluded from recording.
         """
         sensor = self._create_area_sensor("Area")
         unrecorded = getattr(sensor, "_unrecorded_attributes", frozenset())
 
-        assert "area_is_stale" not in unrecorded
-        assert "area_retained" not in unrecorded
-        assert "area_source" not in unrecorded
+        assert "area_is_stale" in unrecorded
+        assert "area_retained" in unrecorded
+        assert "area_source" in unrecorded
 
     def test_area_sensor_includes_time_metadata_in_attributes(self) -> None:
         """BASELINE: Area sensor includes time-based metadata in extra_state_attributes.


### PR DESCRIPTION
Entities were recording frequently-changing attributes (every coordinator cycle ~1.05s) to the HA recorder database, causing ~1GB/day growth.

- binary_sensor: Exclude last_seen_age_seconds via MATCH_ALL (changes every cycle)
- device_tracker: Exclude scanner/area attrs via MATCH_ALL (duplicates sensor data)
- sensor (AreaSwitchReason): Exclude diagnostic dict via MATCH_ALL (changes every cycle)
- sensor (base): Exclude area_is_stale, area_retained, area_source metadata

Live state, UI, automations and templates are NOT affected — only the recorder database is relieved from storing these volatile attributes.

https://claude.ai/code/session_012kcc55LXowNCpEdkzh8bbt